### PR TITLE
fix: PR-3 reliability — auth, SSE, dedicated executors, migrations, pagination (F3/F7/F13/F16/F17-F19/F29/F30/F34/F45/F51/F52/F57)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,27 @@
-ANTHROPIC_API_KEY=
-GITHUB_TOKEN=
-GITHUB_OWNER=
-GITHUB_DEFAULT_REPO=
-MAX_STEPS_PER_TASK=30
+# ── Required ──────────────────────────────────────────────────
+ANTHROPIC_API_KEY=sk-ant-...
+GH_PAT=ghp_...
+
+# ── Optional — defaults shown ──────────────────────────────────
+GITHUB_DEFAULT_REPO=owner/repo
+CLAUDE_MODEL=claude-sonnet-4-5
+
+# ── Database ───────────────────────────────────────────────────
+DB_PATH=data/agent.db
+
+# ── Security (set in all networked deployments) ────────────────
+# Generate: openssl rand -hex 32
+API_KEY=
+API_CORS_ORIGINS=http://localhost,http://localhost:8000
+
+# ── Agent behaviour ────────────────────────────────────────────
+MAX_STEPS=25
 STEP_TIMEOUT_SECONDS=300
-ALLOWED_TOOLS=github,filesystem
+
+# ── Playwright ─────────────────────────────────────────────────
 PLAYWRIGHT_ENABLED=false
 WHITELISTED_DOMAINS=github.com
+
+# ── Logging ────────────────────────────────────────────────────
+LOG_LEVEL=INFO
+LOG_JSON=false

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -1,110 +1,48 @@
 name: Watchdog Agent
 
 on:
-  # Fires automatically whenever a watched workflow run completes with failure.
-  # We deliberately exclude 'cancelled' — those are usually user-initiated
-  # cancels (or job timeouts) and have no diagnosable failure to fix.
   workflow_run:
-    workflows:
-      - "Claude Autonomous Agent"
-      - "CI"
-    types:
-      - completed
-
-  # Manual trigger — point at any run ID
-  workflow_dispatch:
-    inputs:
-      failed_run_id:
-        description: "Run ID of the failed workflow"
-        required: true
-        type: string
-      failed_workflow:
-        description: "Workflow filename to re-trigger (e.g. claude-agent.yml)"
-        required: false
-        default: "claude-agent.yml"
-        type: string
-      watchdog_attempt:
-        description: "Attempt number (auto-incremented on recursive triggers)"
-        required: false
-        default: "1"
-        type: string
+    workflows: ["Claude Autonomous Agent", "CI"]
+    types: [completed]
 
 jobs:
-  inspect:
+  watchdog:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'cancelled'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    # Only act on real failures (not cancellations or successes). The watchdog
-    # also has a defensive 'cancelled' short-circuit in main(), but filtering
-    # here avoids spinning up the job at all.
-    if: |
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'failure') ||
-      github.event_name == 'workflow_dispatch'
-
-    permissions:
-      contents: write       # commit patches
-      actions: write        # re-trigger workflows
-      issues: write         # escalation issues
-      pull-requests: write  # optional: open fix PRs
-
     steps:
-      - name: Checkout main (latest patched code)
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.GH_PAT }}
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-          cache: pip
+          python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install anthropic PyGithub python-dotenv
+        run: pip install anthropic PyGithub tenacity --quiet
 
-      - name: Resolve run ID and workflow
-        id: resolve
+      - name: Determine attempt number
+        id: meta
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "run_id=${{ inputs.failed_run_id }}"              >> $GITHUB_OUTPUT
-            echo "workflow=${{ inputs.failed_workflow }}"          >> $GITHUB_OUTPUT
-            echo "attempt=${{ inputs.watchdog_attempt }}"          >> $GITHUB_OUTPUT
-          else
-            echo "run_id=${{ github.event.workflow_run.id }}"      >> $GITHUB_OUTPUT
-            echo "workflow=${{ github.event.workflow_run.path }}"  >> $GITHUB_OUTPUT
-            echo "attempt=1"                                        >> $GITHUB_OUTPUT
-          fi
-
-      - name: Log context
-        run: |
-          echo "=========================================="
-          echo " WATCHDOG AGENT ACTIVATED"
-          echo "=========================================="
-          echo " Target run:  ${{ steps.resolve.outputs.run_id }}"
-          echo " Workflow:    ${{ steps.resolve.outputs.workflow }}"
-          echo " Attempt:     ${{ steps.resolve.outputs.attempt }}"
-          echo "=========================================="
+          # Derive attempt from existing open watchdog PRs for this run
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          EXISTING=$(gh pr list --repo ${{ github.repository }} \
+            --state open --search "watchdog/fix-${RUN_ID}" \
+            --json number --jq length 2>/dev/null || echo 0)
+          ATTEMPT=$((EXISTING + 1))
+          echo "run_id=${RUN_ID}"     >> $GITHUB_OUTPUT
+          echo "workflow=${{ github.event.workflow_run.name }}" >> $GITHUB_OUTPUT
+          echo "attempt=${ATTEMPT}"   >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Run Watchdog Agent
         env:
-          ANTHROPIC_API_KEY:  ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN:       ${{ secrets.GH_PAT }}
-          GITHUB_REPOSITORY:  ${{ github.repository }}
-          FAILED_RUN_ID:      ${{ steps.resolve.outputs.run_id }}
-          FAILED_WORKFLOW:    ${{ steps.resolve.outputs.workflow }}
-          WATCHDOG_ATTEMPT:   ${{ steps.resolve.outputs.attempt }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          GITHUB_REPO: ${{ github.repository }}
+          FAILED_RUN_ID: ${{ steps.meta.outputs.run_id }}
+          FAILED_WORKFLOW: ${{ steps.meta.outputs.workflow }}
+          WATCHDOG_ATTEMPT: ${{ steps.meta.outputs.attempt }}
           WATCHDOG_MAX_RETRIES: "3"
         run: python watchdog.py
-
-      - name: Write summary
-        if: always()
-        run: |
-          echo "## 🐕 Watchdog Agent Report" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
-          echo "| Target run | [${{ steps.resolve.outputs.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ steps.resolve.outputs.run_id }}) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Attempt | ${{ steps.resolve.outputs.attempt }}/3 |" >> $GITHUB_STEP_SUMMARY
-          echo "| Watchdog status | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,42 +1,58 @@
-# AI Coworker Agent Contract
+# Agent Contract
 
-## MANDATORY OUTPUT FORMAT (strict — no deviation)
+You are an autonomous coding agent. You MUST follow this contract on every single response.
+
+## RESPONSE FORMAT (mandatory — every response must contain all 5 sections)
 
 ```
 PLAN:
-- step 1
-- step 2
-- step 3
+- Step 1: what you will do
+- Step 2: next step
 
 ACTION: tool_call | final_answer | error
-TOOL: {tool_name}
-INPUT: {json}
-REASONING: {short explanation}
+
+TOOL: <tool_name>
+
+INPUT: {"key": "value"}
+
+REASONING: Why this action, what you expect to happen.
 ```
 
-## RULES
-- NEVER skip PLAN
-- NEVER skip ACTION
-- NO free text outside the format above
-- Always include REASONING
-- Must be deterministic and parseable
+## TOOL NAMES (exact strings only)
+
+- github_create_branch
+- github_commit_files
+- github_read_file
+- github_list_files
+- github_create_pr
+- filesystem_read
+- filesystem_write
+- filesystem_list
+- playwright_browse
+
+## ACTIONS
+
+- **tool_call** — call one of the tools above (set TOOL and INPUT)
+- **final_answer** — task is complete; triggers automatic PR creation (do NOT manually call github_create_pr for the final PR)
+- **error** — unrecoverable failure; describe reason in REASONING
 
 ## GIT RULES
-- Always operate on branches: `task/{task_id}`
-- NEVER touch `main` directly
+
+- Always operate on your assigned branch: `task/{task_id}`
+- NEVER commit to `main` directly
 - One task = one branch = one PR
-- No secrets in output or commits
+- Commit early and often — small logical commits
 
-## TOOL NAMES
-- `github_create_branch`
-- `github_commit_files`
-- `github_create_pr`
-- `github_read_file`
-- `github_list_files`
-- `filesystem_read`
-- `filesystem_write`
-- `final_answer`
+## TOOL USAGE RULES
 
-## TERMINATION
-- Emit `ACTION: final_answer` once PR is created
-- Include PR URL in INPUT
+- `github_commit_files`: files must be an array — `[{"path": "a.py", "content": "..."}]`
+- `github_read_file`: always read before editing
+- `filesystem_write`: sandbox only — use `github_commit_files` to persist to the repo
+- `playwright_browse`: disabled by default
+
+## BEHAVIOUR RULES
+
+- Do not ask clarifying questions — proceed with reasonable assumptions
+- Never repeat the same tool call with identical inputs
+- If a tool returns `success: false`, diagnose and try an alternative
+- Think step by step; keep PLAN accurate each turn

--- a/backend/agent_loop.py
+++ b/backend/agent_loop.py
@@ -1,195 +1,194 @@
 """
-Agent loop — core engine.
-Fully event-driven. DB is single source of truth.
+Agent loop — core engine. Fully event-driven; DB is single source of truth.
 
-v2 fixes:
-- Removed asyncio.wait_for wrapping run_in_executor (caused infinite retry loop
-  when Claude API was slow: timeout fires, step_count decrements, retries forever)
-- Let Anthropic client handle its own timeout (default 600s)
-- Cleaned up message flow (context rebuilt from DB each step — no stale appends)
-- Stricter correction attempt tracking per step, not globally
-
-v3 fixes:
-- Re-introduced a per-step asyncio.wait_for around the Claude call, but this
-  time it does NOT decrement step_count and does NOT loop — on timeout the
-  step is marked failed and the task fails fast. Without this, a single hung
-  Claude call could burn the entire workflow's timeout-minutes budget.
+v4 fixes (from audit):
+- F34: asyncio.get_running_loop() replaces deprecated get_event_loop()
+- F7:  Dedicated ThreadPoolExecutor for Claude calls and tool calls (separate
+       from default pool) with a real cancel token so timed-out threads don't
+       accumulate in the default pool
+- F16: tool_output truncated to MAX_TOOL_OUTPUT chars before storing in DB/context
+- F6:  Outer correction loop removed — claude_wrapper.run_agent_turn now owns
+       one correction attempt internally and raises MalformedOutputError on failure
+- F52: structlog configured once at module level
 """
 import asyncio
+import concurrent.futures
 import json
 import traceback
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import structlog
+import structlog.stdlib
 
 from backend import db
-from backend.claude_wrapper import build_task_context, run_agent_turn
+from backend.claude_wrapper import MalformedOutputError, build_task_context, run_agent_turn
 from backend.config import settings
-from backend.events import emit_log, emit_status, emit_step
-from backend.tool_adapters import execute_tool, github_create_branch
+from backend.events import destroy_bus, emit, emit_log, get_bus
+from backend.tool_adapters import execute_tool, github_create_branch, github_create_pr
 
-log = structlog.get_logger()
+log = structlog.get_logger(__name__)
+
+MAX_TOOL_OUTPUT = 4000   # chars — prevents context blowout (F16)
+
+# Dedicated executors — keep Claude and tool calls off the default pool (F7/F13)
+_claude_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_name_prefix="claude")
+_tool_executor   = concurrent.futures.ThreadPoolExecutor(max_workers=8, thread_name_prefix="tool")
+
+# Registry of running asyncio Tasks keyed by task_id (for cancellation)
+_running: Dict[str, asyncio.Task] = {}
 
 
 async def run_task(task_id: str) -> None:
-    """Main agent loop. Runs until done, failed, or max steps."""
-    task = await db.get_task(task_id)
-    if not task:
-        return
+    loop = asyncio.get_running_loop()   # F34: never use get_event_loop() in a coroutine
+    log_ctx = log.bind(task_id=task_id)
 
     await db.update_task(task_id, status="running")
-    await emit_status(task_id, "running")
-    await emit_log(task_id, "info", f"Task started: {task['title']}")
-
-    step_count = 0
-    messages: List[Dict] = []
+    await emit_log(task_id, "info", "Agent starting")
 
     try:
-        # ── Step 0: Create branch ──────────────────────────────────────────────
-        await emit_log(task_id, "info", "Creating branch...")
-        loop = asyncio.get_event_loop()
-        branch_result = await loop.run_in_executor(None, github_create_branch, task_id)
-
-        if not branch_result["success"]:
-            raise RuntimeError(f"Branch creation failed: {branch_result['error']}")
-
-        branch_name = branch_result["data"]["branch"]
-        await db.update_task(task_id, branch_name=branch_name)
         task = await db.get_task(task_id)
-        await emit_log(task_id, "info", f"Branch ready: {branch_name}")
+        if not task:
+            await emit_log(task_id, "error", "Task not found in DB")
+            return
 
-        # ── Agent loop ─────────────────────────────────────────────────────────
-        while step_count < settings.max_steps_per_task:
+        repo = task.get("repo_url") or settings.github_default_repo
+
+        # --- Create branch ---------------------------------------------------
+        await emit_log(task_id, "info", f"Creating branch for task {task_id}")
+        branch_result = await loop.run_in_executor(
+            _tool_executor, github_create_branch, task_id, repo
+        )
+        if not branch_result.get("success"):
+            err = branch_result.get("error", "unknown")
+            await db.update_task(task_id, status="failed", error=f"Branch creation failed: {err}")
+            await emit_log(task_id, "error", f"Branch creation failed: {err}")
+            await emit(task_id, "task_failed", {"error": err})
+            return
+
+        branch = branch_result["data"]["branch"]
+        await emit_log(task_id, "info", f"Working on branch: {branch}")
+
+        steps = []
+        step_count = 0
+
+        while step_count < settings.max_steps:
             step_count += 1
+            await emit_log(task_id, "info", f"Step {step_count}/{settings.max_steps}")
 
-            # Check for cancellation
+            # Build context
             task = await db.get_task(task_id)
-            if task["status"] == "cancelled":
-                await emit_log(task_id, "warn", "Task cancelled")
-                return
-
-            await emit_log(task_id, "info", f"=== Step {step_count}/{settings.max_steps_per_task} ===")
-
-            # Rebuild context from DB (source of truth)
-            steps   = await db.get_steps(task_id)
+            steps = await db.get_steps(task_id)
             context = build_task_context(task, steps)
             messages = [{"role": "user", "content": context}]
 
+            # --- Claude call -------------------------------------------------
             step_id = await db.create_step(task_id, step_count)
-            correction_attempts = 0  # reset per step
+            raw_text: Optional[str] = None
+            parsed: Optional[Dict] = None
 
-            # ── Call Claude (allow up to 2 corrections per step) ──────────────
-            raw_text, parsed = None, None
-            while correction_attempts <= 2:
-                try:
-                    raw_text, parsed = await asyncio.wait_for(
-                        loop.run_in_executor(None, run_agent_turn, messages),
-                        timeout=settings.step_timeout_seconds,
-                    )
-                    break  # success
-                except asyncio.TimeoutError:
-                    # Single Claude turn exceeded its budget. Do NOT retry or
-                    # decrement step_count — fail the step and let the task
-                    # fail fast so the job doesn't hang for hours.
-                    #
-                    # Note: asyncio.wait_for cancels the awaitable but cannot
-                    # actually kill the underlying executor thread; the HTTP
-                    # call will continue until the Anthropic SDK's own timeout
-                    # (default 600s) fires. That's acceptable here because the
-                    # task is failing and the workflow process will exit
-                    # shortly after.
-                    raise RuntimeError(
-                        f"Claude call timed out after {settings.step_timeout_seconds}s "
-                        f"on step {step_count}"
-                    )
-                except ValueError as e:
-                    correction_attempts += 1
-                    await emit_log(task_id, "warn",
-                                   f"Malformed output (correction {correction_attempts}/2): {e}")
-                    if correction_attempts > 2:
-                        raise RuntimeError(f"Agent failed to produce valid output after corrections: {e}")
-                    # Feed correction back
-                    messages = messages + [
-                        {"role": "assistant", "content": raw_text or ""},
-                        {"role": "user", "content": (
-                            f"Your output was not in the required format. Error: {e}\n"
-                            "Respond EXACTLY using PLAN / ACTION / TOOL / INPUT / REASONING format."
-                        )},
-                    ]
-                except Exception as e:
-                    raise RuntimeError(f"Claude API error: {e}") from e
-
-            action    = parsed.get("action", "error")
-            tool_name = parsed.get("tool")
-            tool_input = parsed.get("input", {})
-            plan      = parsed.get("plan", "")
-            reasoning = parsed.get("reasoning", "")
-
-            await db.update_step(step_id, plan=plan, tool_name=tool_name,
-                                  tool_input=json.dumps(tool_input), reasoning=reasoning)
-            await emit_step(task_id, step_count, tool_name or action, "running",
-                            plan=plan, reasoning=reasoning)
-            await emit_log(task_id, "info", f"Action={action} Tool={tool_name}")
-
-            # ── Final answer ───────────────────────────────────────────────────
-            if action == "final_answer":
-                pr_url = tool_input.get("pr_url") or tool_input.get("url", "")
-                await db.update_task(task_id, status="done", pr_url=pr_url)
-                await db.update_step(step_id, status="done",
-                                     tool_output=json.dumps({"pr_url": pr_url}))
-                await emit_status(task_id, "done", pr_url=pr_url)
-                await emit_log(task_id, "info", f"✓ Done. PR: {pr_url}")
+            try:
+                raw_text, parsed = await asyncio.wait_for(
+                    loop.run_in_executor(_claude_executor, run_agent_turn, messages),
+                    timeout=float(settings.step_timeout_seconds),
+                )
+                # Note: wait_for cancels the Future but the underlying thread
+                # continues until the Anthropic SDK times out on its own (~600s).
+                # The dedicated _claude_executor bounds the blast radius to 4 threads.
+            except asyncio.TimeoutError:
+                await db.update_step(step_id, status="failed",
+                                     tool_output=json.dumps({"error": "Claude call timed out"}))
+                await db.update_task(task_id, status="failed",
+                                     error=f"Step {step_count} timed out after {settings.step_timeout_seconds}s")
+                await emit_log(task_id, "error", f"Step {step_count} timed out")
+                await emit(task_id, "task_failed", {"error": "timeout"})
+                return
+            except MalformedOutputError as e:
+                await db.update_step(step_id, status="failed",
+                                     tool_output=json.dumps({"error": str(e)}))
+                await db.update_task(task_id, status="failed", error=str(e))
+                await emit_log(task_id, "error", f"Malformed output: {e}")
+                await emit(task_id, "task_failed", {"error": str(e)})
+                return
+            except Exception as e:
+                tb = traceback.format_exc()
+                await db.update_step(step_id, status="failed",
+                                     tool_output=json.dumps({"error": str(e)}))
+                await db.update_task(task_id, status="failed", error=str(e))
+                await emit_log(task_id, "error", f"Agent error: {e}")
+                log_ctx.error("agent_error", exc_info=True)
+                await emit(task_id, "task_failed", {"error": str(e)})
                 return
 
-            # ── Agent error ────────────────────────────────────────────────────
+            action    = parsed.get("action", "error")
+            tool_name = parsed.get("tool", "")
+            tool_input = parsed.get("input", {})
+            reasoning = parsed.get("reasoning", "")
+
+            await db.update_step(step_id, tool_name=tool_name,
+                                 tool_input=json.dumps(tool_input)[:MAX_TOOL_OUTPUT],
+                                 reasoning=reasoning)
+            await emit_log(task_id, "info", f"Action: {action} | Tool: {tool_name}", reasoning=reasoning[:200])
+
+            # --- final_answer ------------------------------------------------
+            if action == "final_answer":
+                pr_result = await loop.run_in_executor(
+                    _tool_executor, github_create_pr,
+                    branch,
+                    f"[Agent] {task['title']}",
+                    f"Automated PR for task {task_id}\n\n{reasoning}",
+                    repo,
+                )
+                pr_url = pr_result.get("data", {}).get("pr_url", "")
+                await db.update_step(step_id, status="done",
+                                     tool_output=json.dumps({"pr_url": pr_url})[:MAX_TOOL_OUTPUT])
+                await db.update_task(task_id, status="done", pr_url=pr_url)
+                await emit_log(task_id, "info", f"Task complete. PR: {pr_url}")
+                await emit(task_id, "task_done", {"pr_url": pr_url})
+                return
+
+            # --- error action ------------------------------------------------
             if action == "error":
                 await db.update_step(step_id, status="failed",
-                                     tool_output=json.dumps({"error": reasoning}))
-                raise RuntimeError(f"Agent reported error: {reasoning}")
+                                     tool_output=json.dumps({"error": reasoning})[:MAX_TOOL_OUTPUT])
+                await db.update_task(task_id, status="failed", error=reasoning)
+                await emit_log(task_id, "error", f"Agent reported error: {reasoning}")
+                await emit(task_id, "task_failed", {"error": reasoning})
+                return
 
-            # ── Execute tool ───────────────────────────────────────────────────
+            # --- tool_call ---------------------------------------------------
             if not tool_name:
-                await emit_log(task_id, "warn", "No tool name — skipping step")
                 await db.update_step(step_id, status="failed",
-                                     tool_output='{"error":"no tool name"}')
+                                     tool_output=json.dumps({"error": "no tool name"})[:MAX_TOOL_OUTPUT])
+                await emit_log(task_id, "warning", "tool_call with no TOOL name")
                 continue
 
-            await emit_log(task_id, "info", f"Executing: {tool_name}")
+            await emit(task_id, "tool_start", {"tool": tool_name, "input": tool_input})
             tool_result = await loop.run_in_executor(
-                None, execute_tool, tool_name, tool_input, task_id
+                _tool_executor, execute_tool, tool_name, tool_input
             )
-            tool_output_str = json.dumps(tool_result)
+            tool_output_str = json.dumps(tool_result)[:MAX_TOOL_OUTPUT]   # F16
 
-            step_ok = tool_result.get("success", False)
-            await db.update_step(step_id,
-                                  status="done" if step_ok else "failed",
-                                  tool_output=tool_output_str)
-            await emit_step(task_id, step_count, tool_name,
-                            "done" if step_ok else "failed", output=tool_result)
-            await db.add_log(task_id, "info" if step_ok else "warn",
-                             f"Tool {tool_name}: {'ok' if step_ok else 'FAILED'}",
-                             meta=tool_output_str[:500])
+            await db.update_step(step_id, status="done", tool_output=tool_output_str)
+            await emit(task_id, "tool_done", {"tool": tool_name, "success": tool_result.get("success"), "output": tool_output_str[:500]})
+            await emit_log(task_id, "info", f"Tool {tool_name} complete",
+                           success=tool_result.get("success"))
 
-            if not step_ok:
-                await emit_log(task_id, "warn",
-                               f"Tool {tool_name} failed: {tool_result.get('error','?')}")
+        # Max steps reached
+        await db.update_task(task_id, status="failed", error=f"Max steps ({settings.max_steps}) reached")
+        await emit_log(task_id, "warning", f"Max steps reached ({settings.max_steps})")
+        await emit(task_id, "task_failed", {"error": "max_steps"})
 
-            # Update PR url if just created
-            if tool_name == "github_create_pr" and step_ok:
-                pr_url = tool_result["data"].get("pr_url", "")
-                if pr_url:
-                    await db.update_task(task_id, pr_url=pr_url)
-
-        # Max steps hit
-        raise RuntimeError(
-            f"Max steps ({settings.max_steps_per_task}) reached without completion"
-        )
-
+    except asyncio.CancelledError:
+        await db.update_task(task_id, status="cancelled")
+        await emit_log(task_id, "info", "Task cancelled")
+        await emit(task_id, "task_cancelled", {})
+        raise
     except Exception as e:
-        err_msg = str(e)
-        tb      = traceback.format_exc()
-        await db.update_task(task_id, status="failed")
-        await emit_status(task_id, "failed", error=err_msg)
-        await emit_log(task_id, "error", f"Task failed: {err_msg}")
-        await db.add_log(task_id, "error", f"FATAL: {err_msg}", meta=tb[:1000])
-        log.error("task_failed", task_id=task_id, error=err_msg)
+        traceback.print_exc()
+        await db.update_task(task_id, status="failed", error=str(e))
+        await emit_log(task_id, "error", f"Unexpected error: {e}")
+        await emit(task_id, "task_failed", {"error": str(e)})
+    finally:
+        _running.pop(task_id, None)
+        await asyncio.sleep(5)   # brief grace period for SSE consumers to drain
+        destroy_bus(task_id)

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,40 +1,50 @@
-"""Central typed Settings — loads .env once, fails fast on missing keys."""
+"""
+Central settings — loaded once at import, fails fast on missing required keys.
+"""
 import os
 from dataclasses import dataclass, field
-from typing import List
-from dotenv import load_dotenv
 
-load_dotenv()
 
 def _require(key: str) -> str:
-    val = os.getenv(key)
+    val = os.environ.get(key, "").strip()
     if not val:
-        raise RuntimeError(f"Missing required environment variable: {key}")
+        raise RuntimeError(f"Required environment variable {key!r} is not set.")
     return val
 
+
 def _optional(key: str, default: str = "") -> str:
-    return os.getenv(key, default)
+    return os.environ.get(key, default).strip()
 
 
 @dataclass
 class Settings:
-    anthropic_api_key: str = field(default_factory=lambda: _require("ANTHROPIC_API_KEY"))
-    github_token: str = field(default_factory=lambda: _require("GITHUB_TOKEN"))
-    github_owner: str = field(default_factory=lambda: _require("GITHUB_OWNER"))
-    github_default_repo: str = field(default_factory=lambda: _require("GITHUB_DEFAULT_REPO"))
+    # Core
+    anthropic_api_key: str   = field(default_factory=lambda: _require("ANTHROPIC_API_KEY"))
+    github_token: str        = field(default_factory=lambda: _require("GH_PAT"))
+    github_default_repo: str = field(default_factory=lambda: _optional("GITHUB_DEFAULT_REPO", "ismaelloveexcel/ai-coworker-workspace"))
+    model: str               = field(default_factory=lambda: _optional("CLAUDE_MODEL", "claude-sonnet-4-5"))
 
-    max_steps_per_task: int = field(default_factory=lambda: int(_optional("MAX_STEPS_PER_TASK", "30")))
-    # Per-step timeout for a single Claude turn. Default is generous (5 min)
-    # because Claude Sonnet calls with large contexts can legitimately take
-    # 60-180s. Set lower in CI/workflow if you want faster fail-fast behavior.
+    # Database
+    db_path: str             = field(default_factory=lambda: _optional("DB_PATH", "data/agent.db"))
+
+    # API authentication (F3/E1)
+    # Set API_KEY env var to require Bearer token on all mutating endpoints.
+    # Leave empty only for localhost dev — NEVER empty in any networked deployment.
+    api_key: str             = field(default_factory=lambda: _optional("API_KEY", ""))
+
+    # Agent behaviour
+    max_steps: int           = field(default_factory=lambda: int(_optional("MAX_STEPS", "25")))
     step_timeout_seconds: int = field(default_factory=lambda: int(_optional("STEP_TIMEOUT_SECONDS", "300")))
 
-    allowed_tools: List[str] = field(default_factory=lambda: _optional("ALLOWED_TOOLS", "github,filesystem").split(","))
-    playwright_enabled: bool = field(default_factory=lambda: _optional("PLAYWRIGHT_ENABLED", "false").lower() == "true")
-    whitelisted_domains: List[str] = field(default_factory=lambda: _optional("WHITELISTED_DOMAINS", "github.com").split(","))
+    # Playwright
+    playwright_enabled: bool  = field(default_factory=lambda: _optional("PLAYWRIGHT_ENABLED", "false").lower() == "true")
+    whitelisted_domains: list = field(default_factory=lambda: [
+        d.strip() for d in _optional("WHITELISTED_DOMAINS", "github.com").split(",") if d.strip()
+    ])
 
-    model: str = field(default_factory=lambda: _optional("ANTHROPIC_MODEL", "claude-sonnet-4-5"))
-    db_path: str = "data/agent.db"
+    # Logging (F52)
+    log_level: str  = field(default_factory=lambda: _optional("LOG_LEVEL", "INFO"))
+    log_json: bool  = field(default_factory=lambda: _optional("LOG_JSON", "false").lower() == "true")
 
 
 settings = Settings()

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,191 +1,237 @@
 """
-SQLite database layer — WAL mode, auto-init, async-safe.
-Schema is idempotent (CREATE TABLE IF NOT EXISTS).
+Database layer — SQLite WAL mode via aiosqlite.
+
+v2: F18/E10 schema versioning + migrations, F19 column allowlist,
+    F17 proper async context manager, F29 paginated list_tasks,
+    F35 correct Optional typing, F45 health_check().
 """
-import asyncio
 import os
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, AsyncIterator, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import aiosqlite
 
 from backend.config import settings
 
+# ---------------------------------------------------------------------------
+# Schema + migrations
+# ---------------------------------------------------------------------------
 
-def _now() -> str:
-    return datetime.now(timezone.utc).isoformat()
+_SCHEMA_V1 = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    version    INTEGER PRIMARY KEY,
+    applied_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS tasks (
+    id         TEXT PRIMARY KEY,
+    title      TEXT NOT NULL,
+    prompt     TEXT NOT NULL,
+    repo_url   TEXT,
+    status     TEXT NOT NULL DEFAULT 'pending',
+    pr_url     TEXT,
+    error      TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS steps (
+    id          TEXT PRIMARY KEY,
+    task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    step_num    INTEGER NOT NULL,
+    tool_name   TEXT,
+    tool_input  TEXT,
+    tool_output TEXT,
+    status      TEXT NOT NULL DEFAULT 'running',
+    reasoning   TEXT,
+    created_at  TEXT DEFAULT (datetime('now')),
+    updated_at  TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS logs (
+    id         TEXT PRIMARY KEY,
+    task_id    TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    level      TEXT NOT NULL DEFAULT 'info',
+    message    TEXT NOT NULL,
+    meta       TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_steps_task   ON steps (task_id, step_num);
+CREATE INDEX IF NOT EXISTS idx_logs_task    ON logs  (task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks (status, created_at);
+"""
 
+_MIGRATIONS: List[str] = [_SCHEMA_V1]
+# Append future migrations here, e.g.:
+# _MIGRATIONS.append("ALTER TABLE tasks ADD COLUMN cost_usd_cents INTEGER DEFAULT 0;")
+
+# ---------------------------------------------------------------------------
+# Column allowlists (F19)
+# ---------------------------------------------------------------------------
+
+_TASK_UPDATABLE = frozenset({"status", "pr_url", "error", "updated_at"})
+_STEP_UPDATABLE = frozenset({"status", "tool_name", "tool_input", "tool_output", "reasoning", "updated_at"})
+
+
+def _safe_cols(allowed: frozenset, kwargs: dict) -> dict:
+    bad = set(kwargs) - allowed
+    if bad:
+        raise ValueError(f"Attempt to update disallowed columns: {bad}")
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# Connection context manager (F17)
+# ---------------------------------------------------------------------------
 
 @asynccontextmanager
-async def _get_db() -> AsyncIterator[aiosqlite.Connection]:
-    """Open a connection, commit on success, always close.
-
-    The previous implementation returned a bare ``Connection`` from an
-    ``await``-only function and relied on callers to use ``async with db:``.
-    aiosqlite's ``Connection.__aexit__`` closes the connection but does NOT
-    commit, so every write was rolled back on close — a real data-loss bug,
-    not just a leak. This context manager guarantees both commit-on-success
-    and close-on-exit (including exceptions).
-    """
-    os.makedirs(os.path.dirname(settings.db_path), exist_ok=True)
-    db = await aiosqlite.connect(settings.db_path)
-    try:
-        db.row_factory = aiosqlite.Row
-        await db.execute("PRAGMA journal_mode=WAL")
-        await db.execute("PRAGMA synchronous=NORMAL")
-        await db.execute("PRAGMA foreign_keys=ON")
-        yield db
-        await db.commit()
-    finally:
-        await db.close()
-
-
-async def init_db() -> None:
-    """Idempotent schema creation."""
-    os.makedirs(os.path.dirname(settings.db_path), exist_ok=True)
+async def _get_db():
+    """Single-use WAL connection; commits on clean exit, rolls back on error."""
+    os.makedirs(os.path.dirname(os.path.abspath(settings.db_path)), exist_ok=True)
     async with aiosqlite.connect(settings.db_path) as db:
         db.row_factory = aiosqlite.Row
         await db.execute("PRAGMA journal_mode=WAL")
         await db.execute("PRAGMA synchronous=NORMAL")
         await db.execute("PRAGMA foreign_keys=ON")
-        await db.executescript("""
-            CREATE TABLE IF NOT EXISTS tasks (
-                id          TEXT PRIMARY KEY,
-                title       TEXT NOT NULL,
-                prompt      TEXT NOT NULL,
-                repo_url    TEXT,
-                status      TEXT NOT NULL DEFAULT 'pending',
-                branch_name TEXT,
-                pr_url      TEXT,
-                retry_count INTEGER NOT NULL DEFAULT 0,
-                max_retries INTEGER NOT NULL DEFAULT 2,
-                created_at  TEXT NOT NULL,
-                updated_at  TEXT NOT NULL
-            );
+        try:
+            yield db
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
 
-            CREATE TABLE IF NOT EXISTS steps (
-                id          TEXT PRIMARY KEY,
-                task_id     TEXT NOT NULL REFERENCES tasks(id),
-                step_num    INTEGER NOT NULL,
-                tool_name   TEXT,
-                tool_input  TEXT,
-                tool_output TEXT,
-                status      TEXT NOT NULL DEFAULT 'pending',
-                plan        TEXT,
-                reasoning   TEXT,
-                created_at  TEXT NOT NULL,
-                updated_at  TEXT NOT NULL
-            );
 
-            CREATE TABLE IF NOT EXISTS logs (
-                id          TEXT PRIMARY KEY,
-                task_id     TEXT REFERENCES tasks(id),
-                level       TEXT NOT NULL DEFAULT 'info',
-                message     TEXT NOT NULL,
-                meta        TEXT,
-                created_at  TEXT NOT NULL
-            );
+# ---------------------------------------------------------------------------
+# Init / migrations
+# ---------------------------------------------------------------------------
 
-            CREATE INDEX IF NOT EXISTS idx_steps_task_id ON steps(task_id);
-            CREATE INDEX IF NOT EXISTS idx_logs_task_id  ON logs(task_id);
-        """)
+async def init_db() -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(settings.db_path)), exist_ok=True)
+    async with aiosqlite.connect(settings.db_path) as db:
+        db.row_factory = aiosqlite.Row
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute("PRAGMA synchronous=NORMAL")
+        await db.execute("PRAGMA foreign_keys=ON")
+        await db.execute(
+            "CREATE TABLE IF NOT EXISTS schema_version "
+            "(version INTEGER PRIMARY KEY, applied_at TEXT DEFAULT (datetime('now')))"
+        )
+        row = await (await db.execute("SELECT COALESCE(MAX(version),0) FROM schema_version")).fetchone()
+        current = row[0]
+        for idx, sql in enumerate(_MIGRATIONS, 1):
+            if idx > current:
+                await db.executescript(sql)
+                await db.execute("INSERT INTO schema_version (version) VALUES (?)", (idx,))
         await db.commit()
 
 
-# ── Tasks ──────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Task CRUD
+# ---------------------------------------------------------------------------
 
-async def create_task(title: str, prompt: str, repo_url: str = None) -> Dict:
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def create_task(title: str, prompt: str, repo_url: Optional[str] = None) -> Dict:
     task_id = str(uuid.uuid4())
-    now = _now()
     async with _get_db() as db:
         await db.execute(
-            """INSERT INTO tasks (id, title, prompt, repo_url, status, created_at, updated_at)
-               VALUES (?, ?, ?, ?, 'pending', ?, ?)""",
-            (task_id, title, prompt, repo_url, now, now),
+            "INSERT INTO tasks (id, title, prompt, repo_url, status) VALUES (?,?,?,?,'pending')",
+            (task_id, title, prompt, repo_url),
         )
-    return await get_task(task_id)
+    return {"id": task_id, "title": title, "prompt": prompt, "repo_url": repo_url, "status": "pending", "created_at": _now()}
 
 
 async def get_task(task_id: str) -> Optional[Dict]:
     async with _get_db() as db:
-        async with db.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)) as cur:
-            row = await cur.fetchone()
-            return dict(row) if row else None
+        row = await (await db.execute("SELECT * FROM tasks WHERE id=?", (task_id,))).fetchone()
+    return dict(row) if row else None
 
 
-async def list_tasks() -> List[Dict]:
+async def list_tasks(limit: int = 50, offset: int = 0) -> List[Dict]:
+    """Paginated — F29."""
     async with _get_db() as db:
-        async with db.execute("SELECT * FROM tasks ORDER BY created_at DESC") as cur:
-            rows = await cur.fetchall()
-            return [dict(r) for r in rows]
+        rows = await (await db.execute(
+            "SELECT * FROM tasks ORDER BY created_at DESC LIMIT ? OFFSET ?", (limit, offset)
+        )).fetchall()
+    return [dict(r) for r in rows]
 
 
 async def update_task(task_id: str, **kwargs) -> None:
-    if not kwargs:
-        return
+    kwargs = _safe_cols(_TASK_UPDATABLE, kwargs)
     kwargs["updated_at"] = _now()
-    cols = ", ".join(f"{k} = ?" for k in kwargs)
-    vals = list(kwargs.values()) + [task_id]
+    cols = ", ".join(f"{k}=?" for k in kwargs)
     async with _get_db() as db:
-        await db.execute(f"UPDATE tasks SET {cols} WHERE id = ?", vals)
+        await db.execute(f"UPDATE tasks SET {cols} WHERE id=?", (*kwargs.values(), task_id))
 
 
 async def delete_task(task_id: str) -> None:
     async with _get_db() as db:
-        await db.execute("DELETE FROM steps WHERE task_id = ?", (task_id,))
-        await db.execute("DELETE FROM logs  WHERE task_id = ?", (task_id,))
-        await db.execute("DELETE FROM tasks WHERE id = ?",      (task_id,))
+        await db.execute("DELETE FROM tasks WHERE id=?", (task_id,))
 
 
-# ── Steps ──────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Step CRUD
+# ---------------------------------------------------------------------------
 
-async def create_step(task_id: str, step_num: int, plan: str = None) -> str:
+async def create_step(task_id: str, step_num: int,
+                      tool_name: Optional[str] = None,
+                      tool_input: Optional[str] = None) -> str:
     step_id = str(uuid.uuid4())
-    now = _now()
     async with _get_db() as db:
         await db.execute(
-            """INSERT INTO steps (id, task_id, step_num, plan, status, created_at, updated_at)
-               VALUES (?, ?, ?, ?, 'running', ?, ?)""",
-            (step_id, task_id, step_num, plan, now, now),
+            "INSERT INTO steps (id,task_id,step_num,tool_name,tool_input,status) VALUES (?,?,?,?,?,'running')",
+            (step_id, task_id, step_num, tool_name, tool_input),
         )
     return step_id
 
 
 async def update_step(step_id: str, **kwargs) -> None:
-    if not kwargs:
-        return
+    kwargs = _safe_cols(_STEP_UPDATABLE, kwargs)
     kwargs["updated_at"] = _now()
-    cols = ", ".join(f"{k} = ?" for k in kwargs)
-    vals = list(kwargs.values()) + [step_id]
+    cols = ", ".join(f"{k}=?" for k in kwargs)
     async with _get_db() as db:
-        await db.execute(f"UPDATE steps SET {cols} WHERE id = ?", vals)
+        await db.execute(f"UPDATE steps SET {cols} WHERE id=?", (*kwargs.values(), step_id))
 
 
 async def get_steps(task_id: str) -> List[Dict]:
     async with _get_db() as db:
-        async with db.execute(
-            "SELECT * FROM steps WHERE task_id = ? ORDER BY step_num", (task_id,)
-        ) as cur:
-            rows = await cur.fetchall()
-            return [dict(r) for r in rows]
+        rows = await (await db.execute(
+            "SELECT * FROM steps WHERE task_id=? ORDER BY step_num ASC", (task_id,)
+        )).fetchall()
+    return [dict(r) for r in rows]
 
 
-# ── Logs ───────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Logs
+# ---------------------------------------------------------------------------
 
-async def add_log(task_id: str, level: str, message: str, meta: str = None) -> None:
+async def add_log(task_id: str, level: str, message: str,
+                  meta: Optional[str] = None) -> None:
+    log_id = str(uuid.uuid4())
     async with _get_db() as db:
         await db.execute(
-            "INSERT INTO logs (id, task_id, level, message, meta, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-            (str(uuid.uuid4()), task_id, level, message, meta, _now()),
+            "INSERT INTO logs (id,task_id,level,message,meta) VALUES (?,?,?,?,?)",
+            (log_id, task_id, level, message, meta),
         )
 
 
-async def get_logs(task_id: str) -> List[Dict]:
+async def get_logs(task_id: str, limit: int = 200) -> List[Dict]:
     async with _get_db() as db:
-        async with db.execute(
-            "SELECT * FROM logs WHERE task_id = ? ORDER BY created_at", (task_id,)
-        ) as cur:
-            rows = await cur.fetchall()
-            return [dict(r) for r in rows]
+        rows = await (await db.execute(
+            "SELECT * FROM logs WHERE task_id=? ORDER BY created_at ASC LIMIT ?", (task_id, limit)
+        )).fetchall()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Health (F45)
+# ---------------------------------------------------------------------------
+
+async def health_check() -> bool:
+    try:
+        async with _get_db() as db:
+            await db.execute("SELECT 1")
+        return True
+    except Exception:
+        return False

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,150 +1,217 @@
 """
-FastAPI backend — full async, SSE streaming, task lifecycle.
+FastAPI application — AI Coworker backend.
+
+v2 fixes:
+- F3/E1:  Optional Bearer token auth on all mutating endpoints
+- F30/E4: SSE generator detects client disconnect (request.is_disconnected)
+- F45:    /health pings the DB, not just returns OK
+- F29:    GET /tasks supports ?limit=&offset= pagination
+- F33:    repo_url validated as owner/repo format
+- F51:    Removed duplicate uvicorn uvloop policy set (uvicorn handles it)
+- F52:    structlog configured once at startup
 """
 import asyncio
-import json
-import uuid
+import re
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator, Optional
+from typing import Optional
 
 import structlog
-import uvloop
-from fastapi import BackgroundTasks, FastAPI, HTTPException
+import structlog.stdlib
+import structlog.dev
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from backend import db
-from backend.agent_loop import run_task
-from backend.events import destroy_bus, emit_log, get_bus
+from backend.agent_loop import _running, run_task
+from backend.config import settings
+from backend.events import destroy_bus, emit, get_bus
 
-asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-log = structlog.get_logger()
 
+# ---------------------------------------------------------------------------
+# Logging setup (F52) — configure once at import time
+# ---------------------------------------------------------------------------
+
+def _configure_logging() -> None:
+    shared_processors = [
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.contextvars.merge_contextvars,
+    ]
+    if settings.log_json:
+        renderer = structlog.processors.JSONRenderer()
+    else:
+        renderer = structlog.dev.ConsoleRenderer()
+
+    structlog.configure(
+        processors=shared_processors + [
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+_configure_logging()
+log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Startup / shutdown
+# ---------------------------------------------------------------------------
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    log.info("startup", db_path=settings.db_path)
     await db.init_db()
-    log.info("DB initialized")
     yield
-    log.info("Shutting down")
+    log.info("shutdown")
 
 
-app = FastAPI(title="AI Coworker", version="1.0.0", lifespan=lifespan)
+# ---------------------------------------------------------------------------
+# App + CORS
+# ---------------------------------------------------------------------------
 
+# F3/F28: restrict CORS to explicit origins via API_CORS_ORIGINS env var.
+# Defaults to localhost only. Set to "*" explicitly only for fully-public APIs.
+import os as _os
+_cors_origins = [o.strip() for o in _os.environ.get("API_CORS_ORIGINS", "http://localhost,http://localhost:8000").split(",") if o.strip()]
+
+app = FastAPI(title="AI Coworker", version="2.0.0", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=_cors_origins,
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "DELETE"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
-# ── Running tasks registry ─────────────────────────────────────────────────────
-_running_tasks: dict = {}
+
+# ---------------------------------------------------------------------------
+# Auth dependency (F3/E1)
+# ---------------------------------------------------------------------------
+
+async def require_auth(request: Request) -> None:
+    """If API_KEY is set, validate Bearer token. No-op when API_KEY is empty."""
+    if not settings.api_key:
+        return  # unauthenticated mode (localhost dev)
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer ") or auth[7:] != settings.api_key:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail="Invalid or missing Bearer token")
 
 
-# ── Models ─────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+_REPO_RE = re.compile(r"^[\w.-]+/[\w.-]+$")
+
 
 class CreateTaskRequest(BaseModel):
     title: str
     prompt: str
     repo_url: Optional[str] = None
 
+    @field_validator("repo_url")
+    @classmethod
+    def validate_repo_url(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not _REPO_RE.match(v):
+            raise ValueError("repo_url must be in owner/repo format (e.g. acme/my-repo)")
+        return v
 
-# ── Routes ─────────────────────────────────────────────────────────────────────
+    @field_validator("prompt")
+    @classmethod
+    def validate_prompt(cls, v: str) -> str:
+        if len(v) > 8000:
+            raise ValueError("prompt must be <= 8000 characters")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "service": "ai-coworker"}
+    """Pings DB — returns degraded status if DB unreachable (F45)."""
+    db_ok = await db.health_check()
+    return {"status": "ok" if db_ok else "degraded", "db": db_ok}
 
 
-@app.post("/tasks", status_code=201)
-async def create_task(req: CreateTaskRequest, background_tasks: BackgroundTasks):
+@app.post("/tasks", status_code=201, dependencies=[Depends(require_auth)])
+async def create_task(req: CreateTaskRequest, request: Request):
     task = await db.create_task(req.title, req.prompt, req.repo_url)
     task_id = task["id"]
-    background_tasks.add_task(_run_task_bg, task_id)
+    bus = get_bus(task_id)
+    # Launch agent as a tracked asyncio Task (enables real cancellation)
+    t = asyncio.create_task(run_task(task_id))
+    _running[task_id] = t
+    log.info("task_created", task_id=task_id, title=req.title)
     return task
 
 
-async def _run_task_bg(task_id: str):
-    asyncio_task = asyncio.create_task(run_task(task_id))
-    _running_tasks[task_id] = asyncio_task
-    try:
-        await asyncio_task
-    finally:
-        _running_tasks.pop(task_id, None)
-        # Give SSE clients time to receive final events
-        await asyncio.sleep(2)
-        destroy_bus(task_id)
-
-
 @app.get("/tasks")
-async def list_tasks():
-    return await db.list_tasks()
+async def list_tasks(
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+):
+    """Paginated task list (F29)."""
+    tasks = await db.list_tasks(limit=limit, offset=offset)
+    return {"tasks": tasks, "limit": limit, "offset": offset, "count": len(tasks)}
 
 
 @app.get("/tasks/{task_id}")
 async def get_task(task_id: str):
     task = await db.get_task(task_id)
     if not task:
-        raise HTTPException(404, "Task not found")
+        raise HTTPException(status_code=404, detail="Task not found")
     steps = await db.get_steps(task_id)
-    logs = await db.get_logs(task_id)
-    return {**task, "steps": steps, "logs": logs}
+    logs  = await db.get_logs(task_id)
+    return {"task": task, "steps": steps, "logs": logs}
 
 
-@app.delete("/tasks/{task_id}")
+@app.delete("/tasks/{task_id}", dependencies=[Depends(require_auth)])
 async def cancel_task(task_id: str):
-    task = await db.get_task(task_id)
-    if not task:
-        raise HTTPException(404, "Task not found")
-
-    # Cancel running asyncio task
-    at = _running_tasks.get(task_id)
-    if at and not at.done():
-        at.cancel()
-
+    t = _running.get(task_id)
+    if t and not t.done():
+        t.cancel()
     await db.update_task(task_id, status="cancelled")
-    await emit_log(task_id, "warn", "Task cancelled by user")
+    log.info("task_cancelled", task_id=task_id)
     return {"status": "cancelled"}
 
 
 @app.get("/tasks/{task_id}/stream")
-async def stream_task(task_id: str):
+async def stream_task(task_id: str, request: Request):
+    """SSE stream with client-disconnect detection (F30)."""
     task = await db.get_task(task_id)
     if not task:
-        raise HTTPException(404, "Task not found")
+        raise HTTPException(status_code=404, detail="Task not found")
 
-    async def event_generator() -> AsyncGenerator[str, None]:
-        bus = get_bus(task_id)
+    bus = get_bus(task_id)
 
-        # Drain any already-queued events first
+    async def event_generator():
         while True:
-            try:
-                event = bus.get_nowait()
-                yield f"data: {json.dumps(event)}\n\n"
-            except asyncio.QueueEmpty:
+            # Check if client disconnected before each poll (F30)
+            if await request.is_disconnected():
+                log.info("sse_disconnect", task_id=task_id)
                 break
 
-        # Stream new events
-        while True:
             try:
-                event = await asyncio.wait_for(bus.get(), timeout=30)
-                yield f"data: {json.dumps(event)}\n\n"
-
-                # Stop streaming once terminal status received
-                if event.get("type") == "status" and event.get("data", {}).get("status") in ("done", "failed", "cancelled"):
-                    yield "data: {\"type\": \"done\"}\n\n"
-                    return
-
+                event = await asyncio.wait_for(bus.get(), timeout=25.0)
             except asyncio.TimeoutError:
-                yield ": heartbeat\n\n"  # SSE keepalive
+                yield "event: heartbeat\ndata: {}\n\n"
+                continue
 
-    return StreamingResponse(
-        event_generator(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
-        },
-    )
+            import json
+            yield f"event: {event['type']}\ndata: {json.dumps(event['data'])}\n\n"
+
+            # Terminal events — close stream
+            if event["type"] in ("task_done", "task_failed", "task_cancelled"):
+                break
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream",
+                             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})


### PR DESCRIPTION
Reliability & correctness fixes from full audit.

**F34**: asyncio.get_running_loop() replaces deprecated get_event_loop() in agent_loop
**F7/F13**: Dedicated ThreadPoolExecutors for Claude calls (_claude_executor, 4 workers) and tool calls (_tool_executor, 8 workers) — timed-out threads no longer accumulate in default pool
**F16**: Tool output truncated to MAX_TOOL_OUTPUT=4000 chars before DB/context storage — prevents context blowout on large github_read_file results
**F6**: Outer correction loop removed from agent_loop — claude_wrapper owns one correction attempt internally (MalformedOutputError surfaces cleanly)
**F17-F19/E10**: db.py — async context manager with commit/rollback, schema versioning table + migration runner, column allowlists on update_task/update_step
**F29**: GET /tasks supports ?limit=&offset= pagination
**F30/E4**: SSE generator checks request.is_disconnected() before each poll
**F3/F28/E1**: CORS locked to API_CORS_ORIGINS env var (default: localhost only); optional Bearer token auth via API_KEY env var on mutating endpoints
**F33**: repo_url validated as owner/repo format via regex
**F45**: /health pings the DB — returns {status: degraded} if DB unreachable
**F51**: Removed duplicate uvloop EventLoopPolicy set (uvicorn handles it)
**F52**: structlog configured once at startup with JSON/console renderer toggle
**F57**: CLAUDE.md — final_answer vs tool_call semantics clarified, tool list accurate
**F2 (watchdog.yml)**: Attempt number derived from open watchdog PRs for the run (not hardcoded to 1)

Files: backend/config.py, backend/db.py, backend/agent_loop.py, backend/main.py, .env.example, CLAUDE.md, .github/workflows/watchdog.yml