### PR TITLE
fix: support multi-subscriber SSE event fanout

### DIFF
--- a/backend/events.py
+++ b/backend/events.py
@@ -1,45 +1,46 @@
-"""
-Event bus — one asyncio.Queue per task_id.
-
-v2 fixes:
-- F8:  Queue maxsize=500 prevents unbounded memory growth from slow SSE consumers
-- F31: destroy_bus is called by agent_loop after a 5s grace period (not here)
-- Queues are created lazily per-task and removed by destroy_bus
-"""
+"""Task event bus with one bounded queue per active subscriber."""
 import asyncio
-from typing import Dict
+from typing import Dict, Set
 
-_buses: Dict[str, asyncio.Queue] = {}
+_subscribers: Dict[str, Set[asyncio.Queue]] = {}
 
 MAX_QUEUE = 500   # events; slow consumer gets drops, not OOM (F8)
 
 
-def get_bus(task_id: str) -> asyncio.Queue:
-    if task_id not in _buses:
-        _buses[task_id] = asyncio.Queue(maxsize=MAX_QUEUE)
-    return _buses[task_id]
+def subscribe(task_id: str) -> asyncio.Queue:
+    queue: asyncio.Queue = asyncio.Queue(maxsize=MAX_QUEUE)
+    _subscribers.setdefault(task_id, set()).add(queue)
+    return queue
+
+
+def unsubscribe(task_id: str, queue: asyncio.Queue) -> None:
+    subscribers = _subscribers.get(task_id)
+    if not subscribers:
+        return
+    subscribers.discard(queue)
+    if not subscribers:
+        _subscribers.pop(task_id, None)
 
 
 def destroy_bus(task_id: str) -> None:
-    """Remove bus. Call after agent task is fully done (with grace period)."""
-    _buses.pop(task_id, None)
+    """Remove all subscriber queues for a task after terminal-event grace period."""
+    _subscribers.pop(task_id, None)
 
 
 async def emit(task_id: str, event_type: str, data: dict) -> None:
-    bus = get_bus(task_id)
     event = {"type": event_type, "data": data}
-    try:
-        bus.put_nowait(event)
-    except asyncio.QueueFull:
-        # Drop oldest event to make room (slow consumer — don't block agent)
+    for queue in tuple(_subscribers.get(task_id, set())):
         try:
-            bus.get_nowait()
-        except asyncio.QueueEmpty:
-            pass
-        try:
-            bus.put_nowait(event)
+            queue.put_nowait(event)
         except asyncio.QueueFull:
-            pass  # still full — drop this event
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                pass
 
 
 async def emit_log(task_id: str, level: str, message: str, **extra) -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, field_validator
 from backend import db
 from backend.agent_loop import _running, run_task
 from backend.config import settings
-from backend.events import get_bus
+from backend.events import subscribe, unsubscribe
 from backend.notifier import notify_task_failure
 
 
@@ -470,27 +470,30 @@ async def stream_task(task_id: str, request: Request):
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    bus = get_bus(task_id)
+    queue = subscribe(task_id)
 
     async def event_generator():
-        while True:
-            # Check if client disconnected before each poll (F30)
-            if await request.is_disconnected():
-                log.info("sse_disconnect", task_id=task_id)
-                break
+        try:
+            while True:
+                # Check if client disconnected before each poll (F30)
+                if await request.is_disconnected():
+                    log.info("sse_disconnect", task_id=task_id)
+                    break
 
-            try:
-                event = await asyncio.wait_for(bus.get(), timeout=25.0)
-            except asyncio.TimeoutError:
-                yield "event: heartbeat\ndata: {}\n\n"
-                continue
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=25.0)
+                except asyncio.TimeoutError:
+                    yield "event: heartbeat\ndata: {}\n\n"
+                    continue
 
-            import json
-            yield f"event: {event['type']}\ndata: {json.dumps(event['data'])}\n\n"
+                import json
+                yield f"event: {event['type']}\ndata: {json.dumps(event['data'])}\n\n"
 
-            # Terminal events — close stream
-            if event["type"] in ("task_done", "task_failed", "task_cancelled"):
-                break
+                # Terminal events — close stream
+                if event["type"] in ("task_done", "task_failed", "task_cancelled"):
+                    break
+        finally:
+            unsubscribe(task_id, queue)
 
     return StreamingResponse(event_generator(), media_type="text/event-stream",
                              headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -223,6 +223,41 @@ async def test_get_task_includes_recovery_fields(client):
 
 
 @pytest.mark.asyncio
+async def test_two_sse_streams_for_same_task_receive_event():
+    from backend import db
+    from backend.events import _subscribers, destroy_bus, emit
+    from backend.main import stream_task
+
+    class ConnectedRequest:
+        async def is_disconnected(self):
+            return False
+
+    task = await db.create_task("SSE fanout", "prompt")
+    first = await stream_task(task["id"], ConnectedRequest())
+    second = await stream_task(task["id"], ConnectedRequest())
+
+    await emit(task["id"], "task_done", {"ok": True})
+
+    first_chunk = await first.body_iterator.__anext__()
+    second_chunk = await second.body_iterator.__anext__()
+
+    if isinstance(first_chunk, bytes):
+        first_chunk = first_chunk.decode()
+    if isinstance(second_chunk, bytes):
+        second_chunk = second_chunk.decode()
+
+    assert "event: task_done" in first_chunk
+    assert "event: task_done" in second_chunk
+    assert '"ok": true' in first_chunk
+    assert '"ok": true' in second_chunk
+
+    await first.body_iterator.aclose()
+    await second.body_iterator.aclose()
+    assert task["id"] not in _subscribers
+    destroy_bus(task["id"])
+
+
+@pytest.mark.asyncio
 async def test_get_task_not_found(client):
     r = await client.get("/tasks/nonexistent-id")
     assert r.status_code == 404

--- a/tests/test_auth_read_endpoints.py
+++ b/tests/test_auth_read_endpoints.py
@@ -97,19 +97,15 @@ async def test_query_param_token_rejected_for_non_sse_mutating_endpoints(auth_cl
 async def test_stream_accepts_token_query_param(auth_client):
     """EventSource cannot send headers; SSE endpoint must accept ?token= query param."""
     from backend import db
-    from backend.events import emit
     from unittest.mock import AsyncMock, patch
     from starlette.requests import Request
 
     task = await db.create_task("sse-auth-test", "prompt")
-    # Pre-emit a terminal event so the stream closes immediately once auth passes.
-    await emit(task["id"], "task_done", {})
     # Patch is_disconnected to avoid httpx ASGITransport deadlock in test context.
     # httpx's receive() blocks on asyncio.Event.wait() once the request body is
     # consumed, and the SSE generator blocks on is_disconnected() calling receive().
-    # Returning False immediately lets the generator consume the pre-emitted
-    # task_done event and exit cleanly.
-    with patch.object(Request, "is_disconnected", AsyncMock(return_value=False)):
+    # Returning True immediately lets the generator close after auth passes.
+    with patch.object(Request, "is_disconnected", AsyncMock(return_value=True)):
         r = await auth_client.get(f"/tasks/{task['id']}/stream?token={_API_KEY}")
         assert r.status_code == 200
     # Wrong token via query param still rejects (auth fails before stream starts)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,31 +1,56 @@
-"""Tests for backend.events — bounded queue, drop-oldest on full."""
+"""Tests for backend.events — multi-subscriber fan-out and bounded queues."""
 import pytest
 
-from backend.events import emit, get_bus, destroy_bus, MAX_QUEUE
+from backend.events import MAX_QUEUE, destroy_bus, emit, subscribe, unsubscribe
 
 
 @pytest.mark.asyncio
-async def test_bus_created_on_demand():
-    bus = get_bus("test-task-1")
-    assert bus is not None
+async def test_subscribe_creates_queue():
+    bus = subscribe("test-task-1")
+    assert bus.maxsize == MAX_QUEUE
     destroy_bus("test-task-1")
 
 
 @pytest.mark.asyncio
-async def test_emit_puts_event():
+async def test_two_subscribers_receive_same_event():
     task_id = "test-task-2"
-    bus = get_bus(task_id)
+    first = subscribe(task_id)
+    second = subscribe(task_id)
     await emit(task_id, "log", {"message": "hello"})
-    event = bus.get_nowait()
-    assert event["type"] == "log"
-    assert event["data"]["message"] == "hello"
+
+    first_event = first.get_nowait()
+    second_event = second.get_nowait()
+    assert first_event == second_event == {"type": "log", "data": {"message": "hello"}}
     destroy_bus(task_id)
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_one_subscriber_leaves_other_active():
+    task_id = "test-task-unsubscribe"
+    first = subscribe(task_id)
+    second = subscribe(task_id)
+    unsubscribe(task_id, first)
+
+    await emit(task_id, "log", {"message": "still here"})
+
+    assert first.empty()
+    assert second.get_nowait()["data"]["message"] == "still here"
+    destroy_bus(task_id)
+
+
+@pytest.mark.asyncio
+async def test_emit_with_no_subscribers_succeeds():
+    task_id = "test-task-no-subscribers"
+    await emit(task_id, "log", {"message": "nobody home"})
+
+    from backend.events import _subscribers
+    assert task_id not in _subscribers
 
 
 @pytest.mark.asyncio
 async def test_queue_bounded_drops_oldest():
     task_id = "test-task-bounded"
-    bus = get_bus(task_id)
+    bus = subscribe(task_id)
     # Fill queue to max
     for i in range(MAX_QUEUE):
         await emit(task_id, "log", {"i": i})
@@ -33,14 +58,15 @@ async def test_queue_bounded_drops_oldest():
     await emit(task_id, "log", {"i": MAX_QUEUE})
     # Queue should still have MAX_QUEUE items (not MAX_QUEUE + 1)
     assert bus.qsize() <= MAX_QUEUE
+    assert bus.get_nowait()["data"]["i"] == 1
     destroy_bus(task_id)
 
 
 @pytest.mark.asyncio
 async def test_destroy_removes_bus():
     task_id = "test-task-destroy"
-    get_bus(task_id)
+    subscribe(task_id)
     destroy_bus(task_id)
-    from backend.events import _buses
-    assert task_id not in _buses
+    from backend.events import _subscribers
+    assert task_id not in _subscribers
 


### PR DESCRIPTION
## Scope
- Replace single shared task event queue with per-subscriber fan-out queues.
- Keep bounded queue behavior and non-blocking emit semantics.
- Preserve SSE terminal-event close behavior and cleanup disconnected subscribers.

## Validation
- `py_compile`: passed
- `pytest tests/test_events.py tests/test_api.py -q`: passed
- `pytest tests/ -q`: passed
- `pip-audit`: no known vulnerabilities found

## Residual Risk
- SSE remains live-only; durable history is still task logs in SQLite.