### PR TITLE
feat: add internal operator status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Default model: **`claude-sonnet-4-5`** (set via `CLAUDE_MODEL` env var).
 - `API_CORS_ORIGINS` defaults to localhost; set explicitly for any deployed frontend
 - Task creation and retry endpoints have basic in-process rate limiting and request-size checks; nginx also caps request bodies at 64 KiB and rate-limits `/api/` traffic
 - If the backend restarts mid-task, startup reconciliation marks orphaned running tasks as failed and preserves the branch, PR URL, current step, last action/tool, and recovery note for operator review
+- Authenticated operator endpoints expose internal status at `/operator/status` and allow a local SQLite backup trigger at `/operator/backup`; they return allowlisted operational fields only and never raw API keys or tokens
 - The Watchdog never writes code patches to `main` directly — all fixes go through a PR
 - The Watchdog does write `.watchdog/state.json` to `main` to persist the daily invocation counter; CI is configured to ignore this path (`paths-ignore: .watchdog/**`) so the write does not trigger new CI runs or re-activate the watchdog loop
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -391,6 +391,58 @@ async def get_running_tasks() -> List[Dict]:
     return [dict(r) for r in rows]
 
 
+_OPERATOR_TASK_FIELDS = (
+    "id", "title", "repo_url", "status", "branch", "current_step", "last_action",
+    "last_tool", "heartbeat_at", "recovery_note", "pr_url", "error", "created_at", "updated_at",
+)
+
+
+def _operator_task_row(row: aiosqlite.Row) -> Dict:
+    task = {field: row[field] for field in _OPERATOR_TASK_FIELDS if field in row.keys()}
+    task["repo"] = task.pop("repo_url", None)
+    for field in ("error", "recovery_note"):
+        if task.get(field):
+            task[field] = _redact_text(task[field])
+    return task
+
+
+async def get_task_counts_by_status() -> Dict[str, int]:
+    """Return task counts grouped by status for operator dashboards."""
+    async with _get_db() as db:
+        rows = await (await db.execute(
+            "SELECT status, COUNT(*) as count FROM tasks GROUP BY status ORDER BY status ASC"
+        )).fetchall()
+    return {row["status"]: int(row["count"]) for row in rows}
+
+
+async def get_running_task_summaries() -> List[Dict]:
+    """Return allowlisted operational fields for running tasks."""
+    async with _get_db() as db:
+        rows = await (await db.execute(
+            """SELECT id, title, repo_url, status, branch, current_step, last_action,
+                      last_tool, heartbeat_at, recovery_note, pr_url, error, created_at, updated_at
+               FROM tasks
+               WHERE status='running'
+               ORDER BY created_at ASC"""
+        )).fetchall()
+    return [_operator_task_row(row) for row in rows]
+
+
+async def get_recent_failed_task_summaries(limit: int = 10) -> List[Dict]:
+    """Return allowlisted operational fields for recent failed/interrupted tasks."""
+    async with _get_db() as db:
+        rows = await (await db.execute(
+            """SELECT id, title, repo_url, status, branch, current_step, last_action,
+                      last_tool, heartbeat_at, recovery_note, pr_url, error, created_at, updated_at
+               FROM tasks
+               WHERE status IN ('failed', 'cancelled')
+               ORDER BY updated_at DESC
+               LIMIT ?""",
+            (limit,),
+        )).fetchall()
+    return [_operator_task_row(row) for row in rows]
+
+
 # ---------------------------------------------------------------------------
 # Artifacts
 # ---------------------------------------------------------------------------
@@ -535,10 +587,10 @@ async def get_summary() -> Dict:
     return {
         "tasks_today":        int(t_row["n"])        if t_row else 0,
         "tasks_this_week":    int(w_row["n"])        if w_row else 0,
-        "succeeded_today":    int(t_row["succeeded"]) if t_row else 0,
-        "failed_today":       int(t_row["failed"])    if t_row else 0,
-        "succeeded_this_week": int(w_row["succeeded"]) if w_row else 0,
-        "failed_this_week":   int(w_row["failed"])    if w_row else 0,
+        "succeeded_today":    int(t_row["succeeded"] or 0) if t_row else 0,
+        "failed_today":       int(t_row["failed"] or 0)    if t_row else 0,
+        "succeeded_this_week": int(w_row["succeeded"] or 0) if w_row else 0,
+        "failed_this_week":   int(w_row["failed"] or 0)    if w_row else 0,
         "total_usd_today":    round(float(t_row["usd"]) if t_row else 0.0, 4),
         "total_usd_this_week": round(float(w_row["usd"]) if w_row else 0.0, 4),
     }
@@ -604,3 +656,37 @@ async def backup_database(retention_days: Optional[int] = None) -> Optional[str]
             except OSError:
                 pass
     return backup_path
+
+
+async def backup_status() -> Dict:
+    """Return local SQLite backup status without exposing environment variables."""
+    db_path = os.path.abspath(settings.db_path)
+    backup_dir = os.path.join(os.path.dirname(db_path), "backups")
+    status = {
+        "enabled": settings.backup_enabled,
+        "retention_days": settings.backup_retention_days,
+        "backup_dir_exists": os.path.isdir(backup_dir),
+        "latest_backup": None,
+        "backup_count": 0,
+    }
+    if not os.path.isdir(backup_dir):
+        return status
+
+    backups = []
+    for name in os.listdir(backup_dir):
+        if not name.startswith("agent-") or not name.endswith(".db"):
+            continue
+        path = os.path.join(backup_dir, name)
+        try:
+            backups.append((os.path.getmtime(path), name, os.path.getsize(path)))
+        except OSError:
+            continue
+    status["backup_count"] = len(backups)
+    if backups:
+        mtime, name, size = max(backups)
+        status["latest_backup"] = {
+            "name": name,
+            "created_at": datetime.fromtimestamp(mtime, timezone.utc).isoformat(),
+            "size_bytes": size,
+        }
+    return status

--- a/backend/main.py
+++ b/backend/main.py
@@ -546,6 +546,57 @@ async def add_artifact_version(artifact_id: str, req: ArtifactVersionRequest, wo
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+@app.get("/operator/status", dependencies=[Depends(require_auth)])
+async def operator_status():
+    """Private operator status surface for local supervision and recovery."""
+    db_detail = await db.health_detail()
+    spend = await db.get_summary()
+    return {
+        "app": {
+            "name": "AI Coworker",
+            "version": app.version,
+            "environment": settings.environment,
+            "auth_required": bool(settings.api_key),
+            "model": settings.model,
+            "watchdog_model": settings.watchdog_model,
+        },
+        "db": db_detail,
+        "tasks": {
+            "counts_by_status": await db.get_task_counts_by_status(),
+            "running": await db.get_running_task_summaries(),
+            "recent_failed": await db.get_recent_failed_task_summaries(limit=10),
+        },
+        "spend": {
+            "today_usd": spend["total_usd_today"],
+            "week_usd": spend["total_usd_this_week"],
+            "summary": spend,
+        },
+        "backup": await db.backup_status(),
+        "guardrails": {
+            "max_steps": settings.max_steps,
+            "step_timeout_seconds": settings.step_timeout_seconds,
+            "max_concurrent_tasks": settings.max_concurrent_tasks,
+            "task_create_rate_limit_enabled": settings.task_create_rate_limit_enabled,
+            "task_create_rate_limit_count": settings.task_create_rate_limit_count,
+            "task_create_rate_limit_window_seconds": settings.task_create_rate_limit_window_seconds,
+            "task_request_max_bytes": settings.task_request_max_bytes,
+            "max_task_usd": settings.max_task_usd,
+            "daily_max_usd": settings.daily_max_usd,
+            "zombie_reaper_interval_seconds": settings.zombie_reaper_interval_seconds,
+        },
+    }
+
+
+@app.post("/operator/backup", dependencies=[Depends(require_auth)])
+async def operator_backup():
+    """Trigger a local SQLite backup for the private operator."""
+    backup_path = await db.backup_database()
+    return {
+        "created": bool(backup_path),
+        "backup": await db.backup_status(),
+    }
+
+
 @app.get("/tasks", dependencies=[Depends(require_auth)])
 async def list_tasks(
     limit: int = Query(default=50, ge=1, le=200),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -196,6 +196,101 @@ async def test_list_tasks_pagination(client):
 
 
 @pytest.mark.asyncio
+async def test_operator_status_returns_private_dashboard_shape(client):
+    from backend import db
+
+    running = await db.create_task("Running", "prompt", "owner/repo")
+    failed = await db.create_task("Failed", "prompt", "owner/repo")
+    await db.update_task(
+        running["id"],
+        status="running",
+        branch="task/running",
+        current_step=4,
+        last_action="tool_call",
+        last_tool="github_read_file",
+        recovery_note="Review branch task/running",
+        pr_url="https://github.com/owner/repo/pull/2",
+    )
+    await db.update_task(failed["id"], status="failed", error="boom")
+
+    response = await client.get("/operator/status")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data) == {"app", "db", "tasks", "spend", "backup", "guardrails"}
+    assert data["app"]["name"] == "AI Coworker"
+    assert data["tasks"]["counts_by_status"]["running"] == 1
+    assert data["tasks"]["counts_by_status"]["failed"] == 1
+    assert data["tasks"]["running"][0]["id"] == running["id"]
+    assert data["tasks"]["running"][0]["repo"] == "owner/repo"
+    assert data["tasks"]["running"][0]["branch"] == "task/running"
+    assert data["tasks"]["running"][0]["current_step"] == 4
+    assert data["tasks"]["running"][0]["last_action"] == "tool_call"
+    assert data["tasks"]["running"][0]["last_tool"] == "github_read_file"
+    assert "prompt" not in data["tasks"]["running"][0]
+    assert data["tasks"]["recent_failed"][0]["id"] == failed["id"]
+    assert data["guardrails"]["task_request_max_bytes"] > 0
+
+
+@pytest.mark.asyncio
+async def test_operator_status_redacts_task_errors_and_recovery_notes(client):
+    from backend import db
+
+    task = await db.create_task("Secret failure", "prompt")
+    await db.update_task(
+        task["id"],
+        status="failed",
+        error="token=ghp_abcdefghijklmnopqrstuvwxyz123456",
+        recovery_note="token=ghp_abcdefghijklmnopqrstuvwxyz123456",
+    )
+
+    response = await client.get("/operator/status")
+
+    assert response.status_code == 200
+    payload = response.text
+    assert "ghp_abcdefghijklmnopqrstuvwxyz123456" not in payload
+    assert "[REDACTED]" in payload
+
+
+@pytest.mark.asyncio
+async def test_operator_status_does_not_expose_secret_config_values(client, monkeypatch):
+    monkeypatch.setattr("backend.main.settings.api_key", "super-secret-api-key")
+    monkeypatch.setattr("backend.main.settings.github_token", "ghp_abcdefghijklmnopqrstuvwxyz123456")
+    monkeypatch.setattr("backend.main.settings.anthropic_api_key", "sk-ant-super-secret")
+
+    response = await client.get(
+        "/operator/status",
+        headers={"Authorization": "Bearer super-secret-api-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.text
+    assert "super-secret-api-key" not in payload
+    assert "ghp_abcdefghijklmnopqrstuvwxyz123456" not in payload
+    assert "sk-ant-super-secret" not in payload
+    assert response.json()["app"]["auth_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_operator_backup_triggers_local_backup(client, tmp_path, monkeypatch):
+    from backend import config, db
+
+    monkeypatch.setattr(config.settings, "backup_enabled", True)
+    monkeypatch.setattr(db.settings, "backup_enabled", True)
+    monkeypatch.setattr(config.settings, "backup_retention_days", 14)
+    monkeypatch.setattr(db.settings, "backup_retention_days", 14)
+
+    await db.create_task("Backup", "prompt")
+    response = await client.post("/operator/backup")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created"] is True
+    assert data["backup"]["enabled"] is True
+    assert data["backup"]["backup_count"] >= 1
+
+
+@pytest.mark.asyncio
 async def test_get_task_includes_recovery_fields(client):
     from backend import db
 

--- a/tests/test_auth_read_endpoints.py
+++ b/tests/test_auth_read_endpoints.py
@@ -60,6 +60,26 @@ async def test_list_tasks_accepts_correct_token(auth_client):
 
 
 @pytest.mark.asyncio
+async def test_operator_status_requires_bearer_token(auth_client):
+    missing = await auth_client.get("/operator/status")
+    query = await auth_client.get(f"/operator/status?token={_API_KEY}")
+    good = await auth_client.get("/operator/status", headers={"Authorization": f"Bearer {_API_KEY}"})
+
+    assert missing.status_code == 401
+    assert query.status_code == 401
+    assert good.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_operator_backup_requires_bearer_token(auth_client):
+    missing = await auth_client.post("/operator/backup")
+    query = await auth_client.post(f"/operator/backup?token={_API_KEY}")
+
+    assert missing.status_code == 401
+    assert query.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_query_param_token_rejected_for_non_sse_read_endpoints(auth_client):
     from backend import db
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -62,6 +62,37 @@ async def test_get_running_tasks_returns_only_running_tasks():
 
 
 @pytest.mark.asyncio
+async def test_operator_task_summary_helpers_return_allowlisted_fields():
+    running = await db.create_task("Running", "private prompt", "owner/repo")
+    failed = await db.create_task("Failed", "private prompt", "owner/repo")
+    await db.update_task(running["id"], status="running", branch="task/running", current_step=2)
+    await db.update_task(failed["id"], status="failed", error="boom")
+
+    counts = await db.get_task_counts_by_status()
+    running_rows = await db.get_running_task_summaries()
+    failed_rows = await db.get_recent_failed_task_summaries()
+
+    assert counts["running"] == 1
+    assert counts["failed"] == 1
+    assert running_rows[0]["id"] == running["id"]
+    assert running_rows[0]["repo"] == "owner/repo"
+    assert running_rows[0]["branch"] == "task/running"
+    assert "prompt" not in running_rows[0]
+    assert failed_rows[0]["id"] == failed["id"]
+    assert "prompt" not in failed_rows[0]
+
+
+@pytest.mark.asyncio
+async def test_summary_handles_empty_status_aggregates():
+    summary = await db.get_summary()
+
+    assert summary["tasks_today"] == 0
+    assert summary["succeeded_today"] == 0
+    assert summary["failed_today"] == 0
+    assert summary["total_usd_today"] == 0.0
+
+
+@pytest.mark.asyncio
 async def test_recovery_note_redacts_secrets():
     task = await db.create_task("Secret recovery", "Prompt")
     await db.update_task(task["id"], recovery_note="token=ghp_abcdefghijklmnopqrstuvwxyz123456")
@@ -146,3 +177,19 @@ async def test_backup_database_creates_backup(tmp_path, monkeypatch):
 
     assert backup_path is not None
     assert backup_path.endswith(".db")
+
+
+@pytest.mark.asyncio
+async def test_backup_status_reports_latest_backup(monkeypatch):
+    from backend import config
+
+    monkeypatch.setattr(config.settings, "backup_enabled", True)
+    monkeypatch.setattr(db.settings, "backup_enabled", True)
+
+    await db.create_task("Backup status", "prompt")
+    await db.backup_database()
+    status = await db.backup_status()
+
+    assert status["enabled"] is True
+    assert status["backup_count"] >= 1
+    assert status["latest_backup"]["name"].startswith("agent-")


### PR DESCRIPTION
## Scope
- Add authenticated private operator status endpoint.
- Add safe local SQLite backup trigger endpoint.
- Add allowlisted DB helpers for task/status/backup summaries.

## Validation
- `py_compile`: passed
- `pytest tests/test_api.py tests/test_auth_read_endpoints.py tests/test_db.py -q`: passed
- `pytest tests/ -q`: passed
- `pip-audit`: no known vulnerabilities found

## Residual Risk
- GitHub Advanced Security secret scanning is not enabled on this repository; tests cover non-exposure of raw API/GitHub/Anthropic keys.