### PR TITLE
feat: add market research recipe and artifact outputs

### DIFF
--- a/backend/policy.py
+++ b/backend/policy.py
@@ -29,6 +29,10 @@ _SAFE_NONLOCAL_TOOLS = {
     "secret_scan",
     "humanize_error",
     "cost_status",
+    "web_search",
+    "fetch_url",
+    "source_summarize",
+    "research_compare",
 }
 
 _SENSITIVE_PATH_SEGMENTS = {".ssh", ".gnupg", ".aws", ".azure", ".config", "AppData"}

--- a/backend/tool_adapters.py
+++ b/backend/tool_adapters.py
@@ -9,6 +9,10 @@ v2: Fixed @retry decorators (F4/E3).
     Unbounded _repo_cache replaced with bounded LRU (F11).
 """
 import glob
+import hashlib
+import html
+import ipaddress
+import json
 import os
 import re
 import shutil
@@ -19,7 +23,9 @@ import time
 from base64 import b64decode
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin, urlparse
 
+import httpx
 from github import Auth, Github, GithubException
 from tenacity import RetryError, retry, retry_if_exception, stop_after_attempt, wait_exponential
 
@@ -127,6 +133,74 @@ def _to_text(value: Any) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
     return str(value)
+
+
+def _domain_allowed(domain: str) -> bool:
+    normalized = (domain or "").lower().strip(".")
+    return any(
+        normalized == d.lower().strip(".") or normalized.endswith("." + d.lower().strip("."))
+        for d in settings.whitelisted_domains
+    )
+
+
+def _private_host_reason(host: str) -> str:
+    normalized = (host or "").lower().strip(".")
+    if not normalized:
+        return "missing hostname"
+    if normalized in {"localhost", "0", "0.0.0.0"} or normalized.endswith(".localhost"):
+        return "local hostname"
+    try:
+        ip = ipaddress.ip_address(normalized.strip("[]"))
+    except ValueError:
+        return ""
+    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified:
+        return f"non-public IP address {ip}"
+    return ""
+
+
+def _validate_research_url(url: str) -> Dict:
+    parsed = urlparse(url or "")
+    if parsed.scheme not in ("http", "https"):
+        return _err(f"Scheme not allowed: {parsed.scheme!r}")
+    if parsed.username or parsed.password:
+        return _err("Credentials in URLs are not allowed")
+    host = parsed.hostname or ""
+    private_reason = _private_host_reason(host)
+    if private_reason:
+        return _err(f"Host not allowed: {private_reason}")
+    if not _domain_allowed(host):
+        return _err(f"Domain not whitelisted: {host!r}")
+    return _ok({"parsed": parsed, "host": host})
+
+
+def _clean_web_text(raw: str, limit: int = 50000) -> str:
+    text = re.sub(r"(?is)<(script|style|noscript).*?</\1>", " ", raw or "")
+    text = re.sub(r"(?s)<[^>]+>", " ", text)
+    text = html.unescape(text)
+    text = re.sub(r"[ \t\r\f\v]+", " ", text)
+    text = re.sub(r"\n\s*\n+", "\n\n", text)
+    return _truncate(_redact(text.strip()), limit)
+
+
+def _source_id(url: str) -> str:
+    return hashlib.sha256((url or "").encode("utf-8")).hexdigest()[:16]
+
+
+def _sentences(text: str, limit: int = 8) -> List[str]:
+    chunks = re.split(r"(?<=[.!?])\s+", re.sub(r"\s+", " ", text or "").strip())
+    clean = [chunk.strip() for chunk in chunks if 30 <= len(chunk.strip()) <= 320]
+    return clean[:limit]
+
+
+def _keyword_lines(text: str, keywords: List[str], limit: int = 6) -> List[str]:
+    lines = []
+    for sentence in _sentences(text, 40):
+        lower = sentence.lower()
+        if any(keyword in lower for keyword in keywords):
+            lines.append(sentence)
+        if len(lines) >= limit:
+            break
+    return lines
 
 
 # -- Retry helpers (raise on failure so tenacity can retry) -------------------
@@ -627,6 +701,194 @@ def filesystem_list(path: str = "", task_id: str = "") -> Dict:
         return _err(f"OS error listing {path}: {e}")
 
 
+# -- Research Tools -----------------------------------------------------------
+
+_TEXT_CONTENT_TYPES = (
+    "text/",
+    "application/json",
+    "application/xml",
+    "application/xhtml+xml",
+    "application/rss+xml",
+    "application/atom+xml",
+)
+
+
+def web_search(query: str, max_results: int = 5, provider: str = "disabled") -> Dict:
+    """Search provider shim. It is intentionally disabled until configured."""
+    query = (query or "").strip()
+    if not query:
+        return _err("query is required")
+    max_results = max(1, min(int(max_results), 10))
+    return _err(
+        "web_search is not configured. Add an approved search provider before use; "
+        f"requested provider={provider!r}, max_results={max_results}. Use fetch_url with known source URLs meanwhile."
+    )
+
+
+def fetch_url(url: str, max_bytes: int = 65536, timeout_seconds: float = 10.0) -> Dict:
+    """Fetch public, whitelisted text content with bounded output and provenance."""
+    max_bytes = max(1024, min(int(max_bytes), 262144))
+    timeout_seconds = max(1.0, min(float(timeout_seconds), 20.0))
+    current_url = url
+    visited = []
+    try:
+        headers = {"User-Agent": "ai-coworker-research/1.0", "Accept-Encoding": "identity"}
+        with httpx.Client(timeout=timeout_seconds, follow_redirects=False, headers=headers) as client:
+            for _ in range(4):
+                validation = _validate_research_url(current_url)
+                if not validation.get("success"):
+                    return validation
+                with client.stream("GET", current_url) as response:
+                    visited.append(str(response.url))
+                    if response.is_redirect:
+                        location = response.headers.get("location")
+                        if not location:
+                            return _err("Redirect response missing Location header")
+                        current_url = urljoin(str(response.url), location)
+                        continue
+                    if response.status_code >= 400:
+                        return _err(f"HTTP error fetching URL: {response.status_code}")
+                    content_encoding = response.headers.get("content-encoding", "").lower().strip()
+                    if content_encoding and content_encoding != "identity":
+                        return _err(f"Compressed responses not allowed: {content_encoding!r}")
+                    content_type = response.headers.get("content-type", "").split(";", 1)[0].lower().strip()
+                    if not content_type or not any(content_type.startswith(allowed) for allowed in _TEXT_CONTENT_TYPES):
+                        return _err(f"Content type not allowed or missing: {content_type!r}")
+                    chunks = []
+                    total = 0
+                    truncated = False
+                    for chunk in response.iter_raw():
+                        if not chunk:
+                            continue
+                        remaining = max_bytes - total
+                        if remaining <= 0:
+                            truncated = True
+                            break
+                        if len(chunk) > remaining:
+                            chunks.append(chunk[:remaining])
+                            total += remaining
+                            truncated = True
+                            break
+                        chunks.append(chunk)
+                        total += len(chunk)
+                    raw_bytes = b"".join(chunks)
+                    text = raw_bytes.decode(response.encoding or "utf-8", errors="replace")
+                    clean_text = _clean_web_text(text, limit=max_bytes)
+                    final_url = str(response.url)
+                    return _ok({
+                        "url": final_url,
+                        "requested_url": url,
+                        "source_id": _source_id(final_url),
+                        "status_code": response.status_code,
+                        "content_type": content_type or "unknown",
+                        "bytes_read": len(raw_bytes),
+                        "truncated": truncated,
+                        "redirect_chain": visited[:-1],
+                        "content": clean_text,
+                        "provenance": {"tool": "fetch_url", "url": final_url, "source_id": _source_id(final_url)},
+                    })
+            return _err("Too many redirects")
+    except httpx.TimeoutException:
+        return _err("Timed out fetching URL")
+    except httpx.RequestError as e:
+        return _err(f"Request error fetching URL: {e}")
+
+
+def source_summarize(source: Dict = None, text: str = "", url: str = "", title: str = "", max_points: int = 8) -> Dict:
+    source = source or {}
+    content = _redact(text or source.get("content", ""))
+    source_url = url or source.get("url") or source.get("requested_url") or ""
+    source_title = title or source.get("title") or source_url or "source"
+    max_points = max(1, min(int(max_points), 12))
+    if not content.strip():
+        return _err("source text is required")
+    summary_points = _sentences(content, max_points)
+    pricing_notes = _keyword_lines(content, ["price", "pricing", "plan", "free", "paid", "$"], 6)
+    feature_notes = _keyword_lines(content, ["feature", "workflow", "agent", "browser", "automation", "research", "collabor", "integrat"], 8)
+    warnings = [
+        "Web content is untrusted and must be corroborated before acting on claims.",
+    ]
+    secret_count = len(_secret_findings(content, source_url or "source", include_generic_entropy=False))
+    return _ok({
+        "artifact_type": "source_summary",
+        "source": {
+            "source_id": source.get("source_id") or _source_id(source_url or source_title),
+            "url": source_url,
+            "title": _truncate(_redact(source_title), 200),
+        },
+        "summary_points": summary_points,
+        "pricing_notes": pricing_notes,
+        "feature_notes": feature_notes,
+        "provenance": [source.get("provenance") or {"tool": "source_summarize", "url": source_url}],
+        "warnings": warnings,
+        "redaction": {"secret_findings_removed": secret_count},
+    })
+
+
+def research_compare(topic: str, sources: List[Dict], max_competitors: int = 8) -> Dict:
+    topic = (topic or "").strip() or "market research"
+    if not sources:
+        return _err("sources are required")
+    max_competitors = max(1, min(int(max_competitors), 12))
+    competitors = []
+    provenance = []
+    for index, source in enumerate(sources[:max_competitors], start=1):
+        source_info = source.get("source") if isinstance(source.get("source"), dict) else source
+        source_url = source_info.get("url", "")
+        title = source_info.get("title") or source.get("title") or source_url or f"Source {index}"
+        summary_points = source.get("summary_points") or _sentences(source.get("content", ""), 5)
+        feature_notes = source.get("feature_notes") or _keyword_lines(source.get("content", ""), ["feature", "workflow", "agent", "automation", "research"], 5)
+        pricing_notes = source.get("pricing_notes") or _keyword_lines(source.get("content", ""), ["price", "pricing", "free", "paid", "$"], 3)
+        source_id = source_info.get("source_id") or _source_id(source_url or title)
+        competitors.append({
+            "name": _truncate(_redact(title), 120),
+            "source_id": source_id,
+            "url": source_url,
+            "positioning": summary_points[:2],
+            "features": feature_notes[:5],
+            "pricing_notes": pricing_notes[:3],
+            "strengths_to_borrow": feature_notes[:3] or summary_points[:3],
+            "weaknesses_to_avoid": ["Validate claims against primary sources before implementation."],
+        })
+        provenance.append({"source_id": source_id, "url": source_url, "title": _truncate(_redact(title), 120)})
+
+    feature_names = ["Agent workflow", "Research workflow", "Artifact output", "Pricing clarity"]
+    feature_matrix = []
+    for competitor in competitors:
+        joined = " ".join(competitor["features"] + competitor["pricing_notes"]).lower()
+        feature_matrix.append({
+            "competitor": competitor["name"],
+            "source_id": competitor["source_id"],
+            "features": {
+                "Agent workflow": "agent" in joined or "automation" in joined,
+                "Research workflow": "research" in joined,
+                "Artifact output": "artifact" in joined or "export" in joined or "document" in joined,
+                "Pricing clarity": "price" in joined or "pricing" in joined or "free" in joined or "paid" in joined or "$" in joined,
+            },
+        })
+    return _ok({
+        "artifact_type": "research_brief",
+        "topic": _redact(topic),
+        "competitor_list": competitors,
+        "positioning_comparison": [{"competitor": c["name"], "positioning": c["positioning"], "source_id": c["source_id"]} for c in competitors],
+        "feature_matrix": {"features": feature_names, "rows": feature_matrix},
+        "pricing_notes": [{"competitor": c["name"], "notes": c["pricing_notes"], "source_id": c["source_id"]} for c in competitors],
+        "strengths_to_borrow": [item for c in competitors for item in c["strengths_to_borrow"]][:10],
+        "weaknesses_to_avoid": ["Do not trust uncorroborated marketing claims.", "Do not copy proprietary UX or private data."],
+        "differentiation_strategy": [
+            "Emphasize private local supervision, source-backed artifacts, and explicit operator controls.",
+            "Keep research outputs tied to source IDs so later builder agents can audit assumptions.",
+        ],
+        "recommended_mvp": [
+            "Policy-gated source fetching",
+            "Deterministic source summaries",
+            "Research brief artifact with provenance",
+            "Human review before implementation tasks consume web claims",
+        ],
+        "provenance": provenance,
+    })
+
+
 # -- Playwright (disabled by default) -----------------------------------------
 
 def playwright_browse(url: str) -> Dict:
@@ -640,11 +902,7 @@ def playwright_browse(url: str) -> Dict:
             return _err(f"Scheme not allowed: {parsed.scheme!r}")
         # Domain whitelist: match on exact domain or .subdomain (F20 fix)
         domain = parsed.hostname or ""
-        allowed = any(
-            domain == d or domain.endswith("." + d)
-            for d in settings.whitelisted_domains
-        )
-        if not allowed:
+        if not _domain_allowed(domain):
             return _err(f"Domain not whitelisted: {domain!r}")
         from playwright.sync_api import sync_playwright
         with sync_playwright() as p:
@@ -665,7 +923,8 @@ _ALLOWED_TOOLS = {
     "github_read_file", "github_list_files", "github_compare_branch",
     "filesystem_read", "filesystem_write", "filesystem_list",
     "playwright_browse", "repo_snapshot", "run_tests", "secret_scan",
-    "humanize_error", "cost_status",
+    "humanize_error", "cost_status", "web_search", "fetch_url",
+    "source_summarize", "research_compare",
 }
 
 _TOOL_MAP = {
@@ -684,6 +943,10 @@ _TOOL_MAP = {
     "secret_scan": secret_scan,
     "humanize_error": humanize_error,
     "cost_status": cost_status,
+    "web_search": web_search,
+    "fetch_url": fetch_url,
+    "source_summarize": source_summarize,
+    "research_compare": research_compare,
 }
 
 

--- a/tests/test_research_tools.py
+++ b/tests/test_research_tools.py
@@ -1,0 +1,229 @@
+"""Tests for policy-gated research tools."""
+import gzip
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from backend.tool_adapters import execute_tool, fetch_url, research_compare, source_summarize, web_search
+
+
+def test_fetch_url_rejects_non_http_scheme():
+    result = fetch_url("file:///etc/passwd")
+
+    assert result["success"] is False
+    assert "Scheme not allowed" in result["error"]
+
+
+def test_fetch_url_rejects_credentials():
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://user:pass@example.com/private")
+
+    assert result["success"] is False
+    assert "Credentials" in result["error"]
+
+
+def test_fetch_url_rejects_localhost_even_if_whitelisted():
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["localhost"]
+        result = fetch_url("http://localhost:8000/admin")
+
+    assert result["success"] is False
+    assert "Host not allowed" in result["error"]
+
+
+@pytest.mark.parametrize("ip", ["192.168.1.1", "10.0.0.1", "172.16.0.1", "169.254.1.1"])
+def test_fetch_url_rejects_private_ipv4_ranges(ip):
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = [ip]
+        result = fetch_url(f"http://{ip}/")
+
+    assert result["success"] is False
+    assert "Host not allowed" in result["error"]
+
+
+@pytest.mark.parametrize("host", ["[::1]", "[fe80::1]", "[fc00::dead:beef]"])
+def test_fetch_url_rejects_private_ipv6_ranges(host):
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = [host.strip("[]")]
+        result = fetch_url(f"http://{host}/")
+
+    assert result["success"] is False
+    assert "Host not allowed" in result["error"]
+
+
+def test_fetch_url_rejects_unwhitelisted_domain():
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://evil-example.com/")
+
+    assert result["success"] is False
+    assert "not whitelisted" in result["error"]
+
+
+def test_fetch_url_allows_whitelisted_subdomain(httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.example.com/product",
+        text="Agent workflow research data.",
+        headers={"content-type": "text/plain"},
+    )
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://api.example.com/product")
+
+    assert result["success"] is True
+    assert result["data"]["url"] == "https://api.example.com/product"
+
+
+def test_fetch_url_fetches_redacts_and_tracks_provenance(httpx_mock):
+    httpx_mock.add_response(
+        url="https://example.com/product",
+        text="<html><body><h1>Product</h1><p>Agent workflow and research automation.</p><p>token=placeholder-secret-value</p></body></html>",
+        headers={"content-type": "text/html; charset=utf-8"},
+    )
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://example.com/product", max_bytes=4096)
+
+    assert result["success"] is True
+    data = result["data"]
+    assert data["url"] == "https://example.com/product"
+    assert data["source_id"]
+    assert data["provenance"]["tool"] == "fetch_url"
+    assert "placeholder-secret-value" not in data["content"]
+    assert "[REDACTED]" in data["content"]
+
+
+def test_fetch_url_rejects_missing_content_type(httpx_mock):
+    httpx_mock.add_response(url="https://example.com/file", content=b"binary-ish data")
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://example.com/file")
+
+    assert result["success"] is False
+    assert "Content type not allowed or missing" in result["error"]
+
+
+def test_fetch_url_rejects_compressed_responses_before_body_processing(httpx_mock):
+    httpx_mock.add_response(
+        url="https://example.com/bomb",
+        content=gzip.compress(b"compressed-placeholder"),
+        headers={"content-type": "text/html", "content-encoding": "gzip"},
+    )
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://example.com/bomb")
+
+    assert result["success"] is False
+    assert "Compressed responses not allowed" in result["error"]
+
+
+def test_fetch_url_rejects_redirect_to_unwhitelisted_domain(httpx_mock):
+    httpx_mock.add_response(
+        url="https://example.com/start",
+        status_code=302,
+        headers={"location": "https://evil.com/internal"},
+    )
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://example.com/start")
+
+    assert result["success"] is False
+    assert "not whitelisted" in result["error"]
+
+
+def test_fetch_url_rejects_excessive_redirects(httpx_mock):
+    for index in range(4):
+        httpx_mock.add_response(
+            url=f"https://example.com/r{index}",
+            status_code=302,
+            headers={"location": f"https://example.com/r{index + 1}"},
+        )
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://example.com/r0")
+
+    assert result["success"] is False
+    assert "Too many redirects" in result["error"]
+
+
+def test_fetch_url_truncates_large_responses(httpx_mock):
+    httpx_mock.add_response(
+        url="https://example.com/large",
+        text="x" * 300000,
+        headers={"content-type": "text/plain"},
+    )
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://example.com/large", max_bytes=4096)
+
+    assert result["success"] is True
+    assert result["data"]["truncated"] is True
+    assert result["data"]["bytes_read"] == 4096
+
+
+def test_fetch_url_reports_timeout(httpx_mock):
+    httpx_mock.add_exception(httpx.TimeoutException("slow source"), url="https://example.com/slow")
+    with patch("backend.tool_adapters.settings") as mock_settings:
+        mock_settings.whitelisted_domains = ["example.com"]
+        result = fetch_url("https://example.com/slow", timeout_seconds=1)
+
+    assert result["success"] is False
+    assert "Timed out" in result["error"]
+
+
+def test_web_search_is_policy_controlled_placeholder():
+    result = web_search("agent platforms")
+
+    assert result["success"] is False
+    assert "not configured" in result["error"]
+
+
+def test_source_summarize_returns_source_backed_redacted_summary():
+    result = source_summarize(
+        source={
+            "url": "https://example.com/product",
+            "title": "Example Product",
+            "source_id": "src1",
+            "content": "Example Product has agent workflow automation. Pricing starts with a free plan. API_KEY=abcdefghijklmnop",
+        }
+    )
+
+    assert result["success"] is True
+    data = result["data"]
+    assert data["artifact_type"] == "source_summary"
+    assert data["source"]["source_id"] == "src1"
+    assert data["pricing_notes"]
+    assert "abcdefghijklmnop" not in str(data)
+
+
+def test_research_compare_builds_research_brief_with_sources():
+    result = research_compare(
+        topic="AI coworker competitors",
+        sources=[
+            {
+                "source": {"title": "Example Agent", "url": "https://example.com/agent", "source_id": "src-agent"},
+                "summary_points": ["Example Agent positions itself as an automation product for teams."],
+                "feature_notes": ["It includes agent workflow automation and research workflow support."],
+                "pricing_notes": ["Pricing includes a free tier and paid plans."],
+            }
+        ],
+    )
+
+    assert result["success"] is True
+    data = result["data"]
+    assert data["artifact_type"] == "research_brief"
+    assert data["competitor_list"][0]["source_id"] == "src-agent"
+    assert data["feature_matrix"]["rows"][0]["features"]["Agent workflow"] is True
+    assert data["provenance"][0]["url"] == "https://example.com/agent"
+
+
+def test_execute_tool_dispatches_research_tools():
+    result = execute_tool(
+        "source_summarize",
+        {"text": "This product offers browser automation and research workflow features.", "url": "https://example.com"},
+    )
+
+    assert result["success"] is True
+    assert result["data"]["artifact_type"] == "source_summary"


### PR DESCRIPTION
## Scope
- Add policy-gated research tools: web_search placeholder, fetch_url, source_summarize, and research_compare.
- Route research tools through the existing execute_tool allowlist/dispatcher.
- Return source-backed research artifact payloads with source IDs and provenance metadata, independent of unmerged PR4 artifact persistence.
- Add bounded fetch safeguards: http/https only, whitelist domains/subdomains, credential rejection, private IPv4/IPv6 and localhost blocking, per-hop redirect validation, redirect limit, text content-type allowlist, compressed response rejection, raw streaming max_bytes cap, timeout bounds, and redaction.

## Validation
- Python compile: passed.
- Focused tests: pytest tests/test_research_tools.py tests/test_operator_tools.py tests/test_sanitize.py -q passed, 47 tests.
- Full tests: pytest tests/ -q passed, 167 tests.
- Dependency audit: python -m pip_audit -r requirements.txt --format=json --strict passed with no known vulnerabilities.
- Independent Explore review: initial High/Medium findings fixed; final review reported no remaining High/Medium blockers.

## Notes
- web_search is intentionally disabled until an approved search provider is configured; agents can use fetch_url with known source URLs meanwhile.
- GitHub Advanced Security secret scanning is not enabled for this repository, so MCP secret scanning could not run.
- CLAUDE.md is a protected path and was not edited; research tools are registered in runtime dispatcher allowlists.

## Rollback
- Revert commit 92918b5 to remove the PR6 research tools and tests.