### PR TITLE
feat: add local worker policy and approval enforcement

### DIFF
--- a/backend/policy.py
+++ b/backend/policy.py
@@ -1,0 +1,111 @@
+"""Policy decisions for local worker tool execution."""
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List
+
+
+ALLOW = "allow"
+DENY = "deny"
+REQUIRE_APPROVAL = "require_approval"
+
+_LOCAL_TOOL_CATEGORIES = {
+    "filesystem_read": "filesystem",
+    "filesystem_write": "filesystem",
+    "filesystem_list": "filesystem",
+    "playwright_browse": "browser",
+    "run_tests": "shell_allowlisted",
+}
+
+_SAFE_NONLOCAL_TOOLS = {
+    "github_create_branch",
+    "github_commit_files",
+    "github_create_pr",
+    "github_read_file",
+    "github_list_files",
+    "github_compare_branch",
+    "repo_snapshot",
+    "secret_scan",
+    "humanize_error",
+    "cost_status",
+}
+
+_SENSITIVE_PATH_SEGMENTS = {".ssh", ".gnupg", ".aws", ".azure", ".config", "AppData"}
+_AUDIT_LIMIT = 500
+_POLICY_AUDIT_LOG: List[Dict[str, Any]] = []
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    tool_name: str
+    category: str
+    outcome: str
+    reason: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return asdict(self)
+
+
+def _decision(tool_name: str, category: str, outcome: str, reason: str) -> PolicyDecision:
+    return PolicyDecision(tool_name=tool_name, category=category, outcome=outcome, reason=reason)
+
+
+def _path_from_input(tool_input: Dict[str, Any]) -> str:
+    return str(tool_input.get("path") or "")
+
+
+def _path_segments(path: str) -> List[str]:
+    return [segment for segment in path.replace("\\", "/").split("/") if segment and segment != "."]
+
+
+def _path_policy(tool_name: str, tool_input: Dict[str, Any]) -> PolicyDecision:
+    path = _path_from_input(tool_input)
+    segments = _path_segments(path)
+    lowered_segments = [segment.lower() for segment in segments]
+    if any(segment == ".." for segment in segments):
+        return _decision(tool_name, "filesystem", DENY, "Path traversal is denied by policy")
+    if path.startswith(("/", "~")) or (len(path) > 1 and path[1] == ":"):
+        return _decision(tool_name, "filesystem", DENY, "Absolute and home-directory paths are denied by policy")
+    if any(segment == ".env" or segment.startswith(".env.") for segment in lowered_segments):
+        return _decision(tool_name, "filesystem", DENY, ".env files are denied by policy")
+    if any(segment.lower() in {value.lower() for value in _SENSITIVE_PATH_SEGMENTS} for segment in segments):
+        return _decision(tool_name, "filesystem", DENY, "Credential and secret storage paths are denied by policy")
+    return _decision(tool_name, "filesystem", ALLOW, "Filesystem action is constrained to the task sandbox")
+
+
+def evaluate_tool_call(tool_name: str, tool_input: Dict[str, Any] | None = None) -> PolicyDecision:
+    """Return a policy decision before executing a tool."""
+    tool_input = tool_input or {}
+    if tool_name in _SAFE_NONLOCAL_TOOLS:
+        return _decision(tool_name, "remote_or_support", ALLOW, "Tool is outside the local worker action surface")
+    category = _LOCAL_TOOL_CATEGORIES.get(tool_name)
+    if category is None:
+        return _decision(tool_name, "unknown", DENY, "Unknown tools are denied by policy")
+    if category == "filesystem":
+        return _path_policy(tool_name, tool_input)
+    if category == "shell_allowlisted":
+        suite = str(tool_input.get("suite") or "quick")
+        allowed_suites = {"quick", "frontend", "all", "python_compile", "pytest", "typecheck", "lint", "actionlint"}
+        if suite not in allowed_suites:
+            return _decision(tool_name, category, DENY, f"Test suite {suite!r} is not allowlisted")
+        return _decision(tool_name, category, ALLOW, "Allowlisted test command")
+    if category == "browser":
+        return _decision(tool_name, category, REQUIRE_APPROVAL, "Browser actions require operator approval")
+    return _decision(tool_name, category, REQUIRE_APPROVAL, "Sensitive local action requires operator approval")
+
+
+def record_policy_decision(decision: PolicyDecision) -> None:
+    entry = {"timestamp": time.time(), **decision.to_dict()}
+    _POLICY_AUDIT_LOG.append(entry)
+    if len(_POLICY_AUDIT_LOG) > _AUDIT_LIMIT:
+        del _POLICY_AUDIT_LOG[: len(_POLICY_AUDIT_LOG) - _AUDIT_LIMIT]
+
+
+def get_policy_audit_log(limit: int = 100) -> List[Dict[str, Any]]:
+    bounded_limit = max(1, min(int(limit), _AUDIT_LIMIT))
+    return list(_POLICY_AUDIT_LOG[-bounded_limit:])
+
+
+def clear_policy_audit_log() -> None:
+    _POLICY_AUDIT_LOG.clear()

--- a/backend/tool_adapters.py
+++ b/backend/tool_adapters.py
@@ -25,6 +25,7 @@ from github import Auth, Github, GithubException
 from tenacity import RetryError, retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from backend.config import settings
+from backend.policy import ALLOW, evaluate_tool_call, record_policy_decision
 
 # PyGithub deprecated the positional-token constructor in 2.x and removes it
 # in 3.x. Use the explicit Auth.Token form so we don't break on upgrade.
@@ -688,15 +689,26 @@ _TOOL_MAP = {
 
 
 def execute_tool(tool_name: str, tool_input: Dict, task_id: str = "") -> Dict:
+    tool_input = tool_input or {}
     if tool_name not in _ALLOWED_TOOLS:
-        return _err(f"Unknown tool: {tool_name!r}. Allowed: {sorted(_ALLOWED_TOOLS)}")
-    fn = _TOOL_MAP[tool_name]
+        decision = evaluate_tool_call(tool_name, tool_input)
+        record_policy_decision(decision)
+        result = _err(f"Unknown tool: {tool_name!r}. Allowed: {sorted(_ALLOWED_TOOLS)}")
+        result["policy_decision"] = decision.to_dict()
+        return result
     # Inject task_id into task-scoped tools for per-task sandbox/cost lookup.
     _FS_TOOLS = {"filesystem_read", "filesystem_write", "filesystem_list"}
     if tool_name in _FS_TOOLS and task_id:
         tool_input = {**tool_input, "task_id": task_id}
     if tool_name == "cost_status" and task_id and not tool_input.get("task_id"):
         tool_input = {**tool_input, "task_id": task_id}
+    decision = evaluate_tool_call(tool_name, tool_input)
+    record_policy_decision(decision)
+    if decision.outcome != ALLOW:
+        result = _err(decision.reason)
+        result["policy_decision"] = decision.to_dict()
+        return result
+    fn = _TOOL_MAP[tool_name]
     try:
         return fn(**tool_input)
     except TypeError as e:

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,77 @@
+"""Tests for local worker policy decisions and enforcement."""
+from unittest.mock import Mock, patch
+
+from backend.policy import ALLOW, DENY, REQUIRE_APPROVAL, clear_policy_audit_log, evaluate_tool_call, get_policy_audit_log
+from backend.tool_adapters import execute_tool
+
+
+def test_policy_allows_safe_filesystem_sandbox_path():
+    decision = evaluate_tool_call("filesystem_read", {"path": "notes/result.txt"})
+
+    assert decision.outcome == ALLOW
+    assert decision.category == "filesystem"
+
+
+def test_policy_denies_env_files():
+    decision = evaluate_tool_call("filesystem_write", {"path": "nested/.env.production"})
+
+    assert decision.outcome == DENY
+    assert ".env" in decision.reason
+
+
+def test_policy_denies_absolute_and_home_paths():
+    assert evaluate_tool_call("filesystem_read", {"path": "/tmp/file"}).outcome == DENY
+    assert evaluate_tool_call("filesystem_read", {"path": "~/secrets"}).outcome == DENY
+    assert evaluate_tool_call("filesystem_read", {"path": "C:/Users/me/.ssh/id_rsa"}).outcome == DENY
+
+
+def test_policy_requires_approval_for_browser_even_with_model_flag():
+    decision = evaluate_tool_call("playwright_browse", {"url": "https://github.com", "approved": True})
+
+    assert decision.outcome == REQUIRE_APPROVAL
+    assert "approval" in decision.reason.lower()
+
+
+def test_policy_allows_allowlisted_test_suite():
+    decision = evaluate_tool_call("run_tests", {"suite": "python_compile"})
+
+    assert decision.outcome == ALLOW
+
+
+def test_policy_denies_non_allowlisted_test_suite_before_tool_runs():
+    decision = evaluate_tool_call("run_tests", {"suite": "shell please"})
+
+    assert decision.outcome == DENY
+    assert "not allowlisted" in decision.reason
+
+
+def test_execute_tool_denies_env_read_before_underlying_tool_runs():
+    sentinel = Mock(side_effect=AssertionError("underlying tool should not run"))
+    with patch.dict("backend.tool_adapters._TOOL_MAP", {"filesystem_read": sentinel}):
+        result = execute_tool("filesystem_read", {"path": ".env"})
+
+    assert result["success"] is False
+    assert result["policy_decision"]["outcome"] == DENY
+    sentinel.assert_not_called()
+
+
+def test_execute_tool_requires_browser_approval_before_underlying_tool_runs():
+    sentinel = Mock(side_effect=AssertionError("underlying tool should not run"))
+    with patch.dict("backend.tool_adapters._TOOL_MAP", {"playwright_browse": sentinel}):
+        result = execute_tool("playwright_browse", {"url": "https://github.com", "approved": True})
+
+    assert result["success"] is False
+    assert result["policy_decision"]["outcome"] == REQUIRE_APPROVAL
+    sentinel.assert_not_called()
+
+
+def test_policy_decisions_are_auditable():
+    clear_policy_audit_log()
+
+    execute_tool("filesystem_read", {"path": ".env"})
+    audit_log = get_policy_audit_log()
+
+    assert len(audit_log) == 1
+    assert audit_log[0]["tool_name"] == "filesystem_read"
+    assert audit_log[0]["outcome"] == DENY
+    assert "timestamp" in audit_log[0]


### PR DESCRIPTION
## Scope
- Add backend policy engine with allow, deny, and require_approval decisions.
- Enforce policy decisions in execute_tool before local filesystem, browser, and allowlisted shell/test actions execute.
- Deny traversal, absolute/home paths, .env files, and common credential storage paths for filesystem tools.
- Require operator approval for browser actions, regardless of model-provided flags.
- Keep allowlisted test suites working and audit every policy decision.

## Validation
- Python compile: passed.
- Focused tests: pytest tests/test_policy.py tests/test_operator_tools.py tests/test_sanitize.py -q passed, 33 tests.
- Full tests: pytest tests/ -q passed, 153 tests.
- Dependency audit: python -m pip_audit -r requirements.txt --format=json --strict passed with no known vulnerabilities.
- Independent Explore review: no High/Medium blockers.

## Notes
- GitHub Advanced Security secret scanning is not enabled on this repository, so MCP secret scanning could not run.
- Approval persistence/API endpoints are intentionally not added yet; require_approval decisions block execution and are auditable through the in-process policy log.

## Rollback
- Revert commit 1a658b4 to remove the policy layer and restore previous execute_tool behavior.