### PR TITLE
feat: add model routing and council mode scaffolding

### DIFF
--- a/backend/agent_loop.py
+++ b/backend/agent_loop.py
@@ -13,6 +13,7 @@ v4 fixes (from audit):
 """
 import asyncio
 import concurrent.futures
+import functools
 import json
 import traceback
 from typing import Dict, Optional
@@ -25,6 +26,7 @@ from backend.claude_wrapper import MalformedOutputError, build_task_context, run
 from backend.config import settings
 from backend.cost_tracker import BudgetExceeded, record_and_check
 from backend.events import destroy_bus, emit, emit_log
+from backend.model_router import infer_task_profile
 from backend.notifier import notify_task_failure
 from backend.tool_adapters import _redact, execute_tool, github_compare_branch, github_create_branch, github_create_pr, humanize_error, run_tests
 
@@ -126,6 +128,7 @@ async def run_task(task_id: str) -> None:
             steps = await db.get_steps(task_id)
             context = build_task_context(task, steps)
             messages = [{"role": "user", "content": context}]
+            route_context = infer_task_profile(task)
 
             # --- Claude call -------------------------------------------------
             step_id = await db.create_step(task_id, step_count)
@@ -134,7 +137,10 @@ async def run_task(task_id: str) -> None:
 
             try:
                 raw_text, parsed, usage = await asyncio.wait_for(
-                    loop.run_in_executor(_claude_executor, run_agent_turn, messages),
+                    loop.run_in_executor(
+                        _claude_executor,
+                        functools.partial(run_agent_turn, messages, route_context),
+                    ),
                     timeout=float(settings.step_timeout_seconds),
                 )
                 # Note: wait_for cancels the Future but the underlying thread
@@ -173,7 +179,7 @@ async def run_task(task_id: str) -> None:
             # Track cost and enforce budget cap
             try:
                 await record_and_check(
-                    task_id, settings.model,
+                    task_id, usage.get("model", settings.model),
                     usage["input_tokens"], usage["output_tokens"],
                 )
             except BudgetExceeded as e:

--- a/backend/claude_wrapper.py
+++ b/backend/claude_wrapper.py
@@ -14,6 +14,7 @@ import anthropic
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from backend.config import settings
+from backend.model_router import route_model
 
 _client = anthropic.Anthropic(api_key=settings.anthropic_api_key, timeout=60.0)
 
@@ -49,9 +50,9 @@ def _anthropic_before_sleep(retry_state) -> None:
     reraise=True,
     before_sleep=_anthropic_before_sleep,
 )
-def _create_message(messages: List[Dict]):
+def _create_message(messages: List[Dict], model: str = None):
     return _client.messages.create(
-        model=settings.model,
+        model=model or settings.model,
         max_tokens=MAX_TOKENS,
         system=_SYSTEM_PROMPT,
         messages=messages,
@@ -278,7 +279,7 @@ class MalformedOutputError(ValueError):
     """Raised when Claude's output is malformed after one correction attempt."""
 
 
-def run_agent_turn(messages: List[Dict]) -> Tuple[str, Dict, Dict]:
+def run_agent_turn(messages: List[Dict], route_context: Optional[Dict[str, str]] = None) -> Tuple[str, Dict, Dict]:
     """
     Call Claude, parse response. One correction attempt on malformed output.
     Returns (raw_text, parsed_action, usage) where usage has input_tokens /
@@ -286,10 +287,18 @@ def run_agent_turn(messages: List[Dict]) -> Tuple[str, Dict, Dict]:
     Raises MalformedOutputError if still malformed after correction.
     Raises anthropic.APIError on API-level failures (let caller retry if needed).
     """
-    response = _create_message(messages)
+    route_context = route_context or {}
+    route = route_model(
+        task_type=route_context.get("task_type", "coding"),
+        risk=route_context.get("risk", "normal"),
+        cost_profile=route_context.get("cost_profile", "standard"),
+    )
+    response = _create_message(messages, model=route.model)
     usage = {
         "input_tokens": response.usage.input_tokens,
         "output_tokens": response.usage.output_tokens,
+        "model": route.model,
+        "model_route": route.to_dict(),
     }
     raw = response.content[0].text
 
@@ -308,7 +317,7 @@ def run_agent_turn(messages: List[Dict]) -> Tuple[str, Dict, Dict]:
                 ),
             },
         ]
-        correction = _create_message(correction_messages)
+        correction = _create_message(correction_messages, model=route.model)
         # Accumulate token usage from the correction call
         usage["input_tokens"] += correction.usage.input_tokens
         usage["output_tokens"] += correction.usage.output_tokens

--- a/backend/config.py
+++ b/backend/config.py
@@ -26,6 +26,15 @@ class Settings:
     watchdog_model: str      = field(default_factory=lambda: _optional("WATCHDOG_MODEL", _optional("CLAUDE_MODEL", "claude-sonnet-4-5-20251101")))
     environment: str         = field(default_factory=lambda: _optional("ENV", _optional("APP_ENV", "development")).lower())
 
+    # Model routing / council mode
+    model_router_enabled: bool = field(default_factory=lambda: _optional("MODEL_ROUTER_ENABLED", "false").lower() == "true")
+    council_mode_enabled: bool = field(default_factory=lambda: _optional("COUNCIL_MODE_ENABLED", "false").lower() == "true")
+    coding_model: str      = field(default_factory=lambda: _optional("CODING_MODEL", ""))
+    research_model: str    = field(default_factory=lambda: _optional("RESEARCH_MODEL", ""))
+    critic_model: str      = field(default_factory=lambda: _optional("CRITIC_MODEL", ""))
+    summarizer_model: str  = field(default_factory=lambda: _optional("SUMMARIZER_MODEL", ""))
+    judge_model: str       = field(default_factory=lambda: _optional("JUDGE_MODEL", ""))
+
     # Database
     db_path: str             = field(default_factory=lambda: _optional("DB_PATH", "data/agent.db"))
 

--- a/backend/model_router.py
+++ b/backend/model_router.py
@@ -1,0 +1,127 @@
+"""Deterministic model routing and council-mode scaffolding."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Iterable, List
+
+from backend.config import settings
+
+
+@dataclass(frozen=True)
+class ModelRoute:
+    provider: str
+    model: str
+    task_type: str
+    risk: str
+    cost_profile: str
+    reason: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return asdict(self)
+
+
+_TASK_MODEL_FIELDS = {
+    "coding": "coding_model",
+    "research": "research_model",
+    "critic": "critic_model",
+    "summarizer": "summarizer_model",
+    "judge": "judge_model",
+}
+
+_RISK_WORDS = {"auth", "token", "secret", "security", "schema", "migration", "deploy", "database", "payment"}
+_RESEARCH_WORDS = {"research", "competitor", "market", "compare", "source", "pricing"}
+_CRITIC_WORDS = {"review", "critic", "audit", "risk", "validate"}
+_SUMMARY_WORDS = {"summarize", "summary", "brief", "recap"}
+_JUDGE_WORDS = {"judge", "decide", "rank", "score", "select"}
+
+
+def _normalize_choice(value: str, default: str) -> str:
+    normalized = (value or "").strip().lower()
+    return normalized or default
+
+
+def _configured_model(field_name: str, settings_obj: Any) -> str:
+    return (getattr(settings_obj, field_name, "") or "").strip()
+
+
+def route_model(task_type: str = "coding", risk: str = "normal", cost_profile: str = "standard", settings_obj: Any = None) -> ModelRoute:
+    """Select a model deterministically, falling back to the default model."""
+    settings_obj = settings_obj or settings
+    selected_task_type = _normalize_choice(task_type, "coding")
+    selected_risk = _normalize_choice(risk, "normal")
+    selected_cost = _normalize_choice(cost_profile, "standard")
+    default_model = settings_obj.model
+
+    if not getattr(settings_obj, "model_router_enabled", False):
+        return ModelRoute("anthropic", default_model, selected_task_type, selected_risk, selected_cost, "router disabled; using default model")
+
+    if selected_risk == "high":
+        configured = _configured_model("critic_model", settings_obj)
+        if configured:
+            return ModelRoute("anthropic", configured, selected_task_type, selected_risk, selected_cost, "high-risk task routed to critic model")
+
+    if selected_cost == "cheap":
+        configured = _configured_model("summarizer_model", settings_obj)
+        if configured:
+            return ModelRoute("anthropic", configured, selected_task_type, selected_risk, selected_cost, "cheap profile routed to summarizer model")
+
+    field_name = _TASK_MODEL_FIELDS.get(selected_task_type, "coding_model")
+    configured = _configured_model(field_name, settings_obj)
+    if configured:
+        return ModelRoute("anthropic", configured, selected_task_type, selected_risk, selected_cost, f"{selected_task_type} task routed by configured model")
+    return ModelRoute("anthropic", default_model, selected_task_type, selected_risk, selected_cost, "router miss; using default model")
+
+
+def infer_task_profile(task: Dict[str, Any]) -> Dict[str, str]:
+    text = f"{task.get('title', '')} {task.get('prompt', '')}".lower()
+    words = set(text.replace("/", " ").replace("-", " ").split())
+    task_type = "coding"
+    if words & _RESEARCH_WORDS:
+        task_type = "research"
+    elif words & _CRITIC_WORDS:
+        task_type = "critic"
+    elif words & _SUMMARY_WORDS:
+        task_type = "summarizer"
+    elif words & _JUDGE_WORDS:
+        task_type = "judge"
+    risk = "high" if words & _RISK_WORDS else "normal"
+    cost_profile = "cheap" if task_type == "summarizer" else "standard"
+    return {"task_type": task_type, "risk": risk, "cost_profile": cost_profile}
+
+
+def council_mode_enabled(settings_obj: Any = None) -> bool:
+    settings_obj = settings_obj or settings
+    return bool(getattr(settings_obj, "council_mode_enabled", False))
+
+
+def build_council_plan(prompt: str, perspectives: Iterable[str] | None = None, settings_obj: Any = None) -> Dict[str, Any]:
+    """Return a deterministic council-mode scaffold without calling providers."""
+    settings_obj = settings_obj or settings
+    selected_perspectives = list(perspectives or ["coding", "critic", "judge"])
+    routes: List[Dict[str, str]] = [
+        route_model(task_type=perspective, risk="normal", cost_profile="standard", settings_obj=settings_obj).to_dict()
+        for perspective in selected_perspectives
+    ]
+    if not council_mode_enabled(settings_obj):
+        return {
+            "enabled": False,
+            "degraded": True,
+            "prompt": prompt,
+            "perspectives": routes[:1],
+            "consensus": "Council mode is disabled; use the default routed model path.",
+            "disagreements": [],
+            "recommended_action": "Run a normal agent turn.",
+            "confidence": "medium",
+            "risk": "low",
+        }
+    return {
+        "enabled": True,
+        "degraded": len({route["model"] for route in routes}) <= 1,
+        "prompt": prompt,
+        "perspectives": routes,
+        "consensus": "Council mode scaffold prepared; provider execution is not implemented in this slice.",
+        "disagreements": [],
+        "recommended_action": "Collect provider responses before taking action.",
+        "confidence": "low",
+        "risk": "medium",
+    }

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -1,0 +1,131 @@
+"""Tests for deterministic model routing and council scaffolding."""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from backend.claude_wrapper import run_agent_turn
+from backend.model_router import build_council_plan, infer_task_profile, route_model
+
+
+DEFAULT_MODEL = "claude-sonnet-4-5-20251101"
+RESEARCH_MODEL = "claude-research-4-5-20251101"
+CRITIC_MODEL = "claude-critic-4-5-20251101"
+SUMMARY_MODEL = "claude-summary-4-5-20251101"
+
+
+def _settings(**overrides):
+    values = {
+        "model": DEFAULT_MODEL,
+        "model_router_enabled": False,
+        "council_mode_enabled": False,
+        "coding_model": "",
+        "research_model": "",
+        "critic_model": "",
+        "summarizer_model": "",
+        "judge_model": "",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_router_disabled_uses_default_model():
+    route = route_model("research", settings_obj=_settings(model_router_enabled=False, research_model=RESEARCH_MODEL))
+
+    assert route.model == DEFAULT_MODEL
+    assert route.reason == "router disabled; using default model"
+
+
+def test_router_uses_task_specific_model_when_enabled():
+    route = route_model("research", settings_obj=_settings(model_router_enabled=True, research_model=RESEARCH_MODEL))
+
+    assert route.model == RESEARCH_MODEL
+    assert route.task_type == "research"
+
+
+def test_router_routes_high_risk_to_critic_model():
+    route = route_model(
+        "coding",
+        risk="high",
+        settings_obj=_settings(model_router_enabled=True, coding_model="claude-code-4-5-20251101", critic_model=CRITIC_MODEL),
+    )
+
+    assert route.model == CRITIC_MODEL
+    assert "high-risk" in route.reason
+
+
+def test_router_routes_cheap_profile_to_summarizer_model():
+    route = route_model(
+        "coding",
+        cost_profile="cheap",
+        settings_obj=_settings(model_router_enabled=True, coding_model="claude-code-4-5-20251101", summarizer_model=SUMMARY_MODEL),
+    )
+
+    assert route.model == SUMMARY_MODEL
+    assert "summarizer" in route.reason
+
+
+def test_router_miss_falls_back_to_default_model():
+    route = route_model("judge", settings_obj=_settings(model_router_enabled=True))
+
+    assert route.model == DEFAULT_MODEL
+    assert "router miss" in route.reason
+
+
+def test_infer_task_profile_detects_research_and_risk():
+    profile = infer_task_profile({"title": "Research competitors", "prompt": "Compare pricing and auth risks"})
+
+    assert profile["task_type"] == "research"
+    assert profile["risk"] == "high"
+
+
+def test_council_mode_degrades_when_disabled():
+    plan = build_council_plan("Review this change", settings_obj=_settings(council_mode_enabled=False))
+
+    assert plan["enabled"] is False
+    assert plan["degraded"] is True
+    assert plan["recommended_action"] == "Run a normal agent turn."
+
+
+def test_council_mode_returns_scaffold_when_enabled():
+    plan = build_council_plan(
+        "Review this change",
+        perspectives=["coding", "critic"],
+        settings_obj=_settings(model_router_enabled=True, council_mode_enabled=True, coding_model="claude-code-4-5-20251101", critic_model=CRITIC_MODEL),
+    )
+
+    assert plan["enabled"] is True
+    assert len(plan["perspectives"]) == 2
+    assert {route["task_type"] for route in plan["perspectives"]} == {"coding", "critic"}
+
+
+class _Usage:
+    input_tokens = 11
+    output_tokens = 7
+
+
+class _Content:
+    text = """PLAN:
+- Step 1: finish
+ACTION: final_answer
+TOOL: none
+INPUT: {}
+REASONING: Done."""
+
+
+class _Response:
+    usage = _Usage()
+    content = [_Content()]
+
+
+def test_run_agent_turn_uses_routed_model_without_changing_parser_flow():
+    routed = SimpleNamespace(model=RESEARCH_MODEL, to_dict=lambda: {"model": RESEARCH_MODEL, "task_type": "research"})
+    with (
+        patch("backend.claude_wrapper.route_model", return_value=routed),
+        patch("backend.claude_wrapper._create_message", return_value=_Response()) as create_message,
+    ):
+        raw, parsed, usage = run_agent_turn([{"role": "user", "content": "Research competitors"}], {"task_type": "research"})
+
+    assert "ACTION: final_answer" in raw
+    assert parsed["action"] == "final_answer"
+    assert usage["model"] == RESEARCH_MODEL
+    create_message.assert_called_once()
+    assert create_message.call_args.kwargs["model"] == RESEARCH_MODEL


### PR DESCRIPTION
## Scope
- Add deterministic model routing scaffold for coding, research, critic, summarizer, and judge profiles.
- Add optional config flags and model fields for router and council mode.
- Thread routed model selection through Claude calls while preserving default single-model behavior when disabled.
- Propagate the routed model into cost tracking.
- Add council-mode plan scaffold that degrades gracefully without executing extra providers.

## Validation
- Python compile: passed.
- Focused tests: pytest tests/test_model_router.py tests/test_parser.py tests/test_agent_loop_gates.py tests/test_cost_tracker.py -q passed, 31 tests.
- Full tests: pytest tests/ -q passed, 153 tests.
- Dependency audit: python -m pip_audit -r requirements.txt --format=json --strict passed with no known vulnerabilities.
- Independent Explore review: no High/Medium blockers.

## Notes
- GitHub Advanced Security secret scanning is not enabled on this repository, so MCP secret scanning could not run.
- Council mode is scaffold-only in this slice; no additional provider credentials or calls are introduced.

## Rollback
- Revert commit a965dca to restore direct settings.model usage.