### PR TITLE
feat: enforce personal-work workspace isolation boundaries

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -122,6 +122,7 @@ CREATE TABLE IF NOT EXISTS artifact_links (
 CREATE INDEX IF NOT EXISTS idx_artifacts_task ON artifacts (task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_artifacts_workspace ON artifacts (workspace, created_at);
 CREATE INDEX IF NOT EXISTS idx_artifact_versions_artifact ON artifact_versions (artifact_id, version_num);
+CREATE INDEX IF NOT EXISTS idx_tasks_workspace_status ON tasks (workspace, status, created_at);
 """
 _MIGRATIONS.append(_SCHEMA_V4)
 
@@ -139,6 +140,21 @@ _ARTIFACT_TYPES = frozenset({
     "app", "document", "slide_deck", "spreadsheet", "research_brief", "campaign_pack",
     "workflow", "code_diff", "dashboard", "design_mockup", "automation_blueprint", "knowledge_base",
 })
+VALID_WORKSPACES = frozenset({"personal", "work"})
+
+
+def normalize_workspace(workspace: Optional[str] = None) -> str:
+    value = (workspace or "personal").strip().lower()
+    if value not in VALID_WORKSPACES:
+        raise ValueError(f"workspace must be one of: {', '.join(sorted(VALID_WORKSPACES))}")
+    return value
+
+
+def _validate_artifact_type(artifact_type: str) -> str:
+    value = (artifact_type or "").strip().lower()
+    if value not in _ARTIFACT_TYPES:
+        raise ValueError(f"artifact_type must be one of: {', '.join(sorted(_ARTIFACT_TYPES))}")
+    return value
 
 
 def _safe_cols(allowed: frozenset, kwargs: dict) -> dict:
@@ -212,52 +228,44 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _validate_workspace(workspace: str) -> str:
-    value = (workspace or "personal").strip().lower()
-    if value not in {"personal", "work"}:
-        raise ValueError("workspace must be one of: personal, work")
-    return value
-
-
-def _validate_artifact_type(artifact_type: str) -> str:
-    value = (artifact_type or "").strip().lower()
-    if value not in _ARTIFACT_TYPES:
-        raise ValueError(f"artifact_type must be one of: {', '.join(sorted(_ARTIFACT_TYPES))}")
-    return value
-
 
 async def create_task(title: str, prompt: str, repo_url: Optional[str] = None, workspace: str = "personal") -> Dict:
     task_id = str(uuid.uuid4())
     safe_title = _redact_text(title) or title
     safe_prompt = _redact_text(prompt) or prompt
-    safe_workspace = _validate_workspace(workspace)
+    workspace = normalize_workspace(workspace)
     async with _get_db() as db:
         await db.execute(
             "INSERT INTO tasks (id, title, prompt, repo_url, status, workspace) VALUES (?,?,?,?, 'pending', ?)",
-            (task_id, safe_title, safe_prompt, repo_url, safe_workspace),
+            (task_id, safe_title, safe_prompt, repo_url, workspace),
         )
     return {
         "id": task_id,
         "title": safe_title,
         "prompt": safe_prompt,
         "repo_url": repo_url,
-        "workspace": safe_workspace,
+        "workspace": workspace,
         "status": "pending",
         "created_at": _now(),
     }
 
 
-async def get_task(task_id: str) -> Optional[Dict]:
+async def get_task(task_id: str, workspace: Optional[str] = None) -> Optional[Dict]:
     async with _get_db() as db:
-        row = await (await db.execute("SELECT * FROM tasks WHERE id=?", (task_id,))).fetchone()
+        if workspace is None:
+            row = await (await db.execute("SELECT * FROM tasks WHERE id=?", (task_id,))).fetchone()
+        else:
+            normalized = normalize_workspace(workspace)
+            row = await (await db.execute("SELECT * FROM tasks WHERE id=? AND workspace=?", (task_id, normalized))).fetchone()
     return dict(row) if row else None
 
 
-async def list_tasks(limit: int = 50, offset: int = 0) -> List[Dict]:
+async def list_tasks(limit: int = 50, offset: int = 0, workspace: str = "personal") -> List[Dict]:
     """Paginated — F29."""
+    workspace = normalize_workspace(workspace)
     async with _get_db() as db:
         rows = await (await db.execute(
-            "SELECT * FROM tasks ORDER BY created_at DESC LIMIT ? OFFSET ?", (limit, offset)
+            "SELECT * FROM tasks WHERE workspace=? ORDER BY created_at DESC LIMIT ? OFFSET ?", (workspace, limit, offset)
         )).fetchall()
     return [dict(r) for r in rows]
 
@@ -458,7 +466,7 @@ async def create_artifact(
 ) -> Dict:
     artifact_id = str(uuid.uuid4())
     version_id = str(uuid.uuid4())
-    safe_workspace = _validate_workspace(workspace)
+    safe_workspace = normalize_workspace(workspace)
     safe_type = _validate_artifact_type(artifact_type)
     safe_title = _redact_text(title) or title
     safe_content = _redact_text(content_json) or "{}"
@@ -523,7 +531,7 @@ async def list_artifacts(task_id: Optional[str] = None, workspace: Optional[str]
         params.append(task_id)
     if workspace:
         filters.append("workspace=?")
-        params.append(_validate_workspace(workspace))
+        params.append(normalize_workspace(workspace))
     where = f"WHERE {' AND '.join(filters)}" if filters else ""
     async with _get_db() as db:
         rows = await (await db.execute(
@@ -551,19 +559,21 @@ async def get_artifact(artifact_id: str) -> Optional[Dict]:
 # Spend aggregates (A8, A9)
 # ---------------------------------------------------------------------------
 
-async def get_daily_spend() -> float:
-    """Sum usd_spent for all tasks created since UTC midnight today (A8)."""
+async def get_daily_spend(workspace: str = "personal") -> float:
+    """Sum usd_spent for one workspace since UTC midnight today (A8)."""
+    workspace = normalize_workspace(workspace)
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     async with _get_db() as db:
         row = await (await db.execute(
-            "SELECT COALESCE(SUM(usd_spent), 0) FROM tasks WHERE created_at >= ?",
-            (today,),
+            "SELECT COALESCE(SUM(usd_spent), 0) FROM tasks WHERE workspace=? AND created_at >= ?",
+            (workspace, today),
         )).fetchone()
     return float(row[0]) if row else 0.0
 
 
-async def get_summary() -> Dict:
+async def get_summary(workspace: str = "personal") -> Dict:
     """Return task count and spend for today and the last 7 days (A9)."""
+    workspace = normalize_workspace(workspace)
     now = datetime.now(timezone.utc)
     today = now.strftime("%Y-%m-%d")
     week_ago = (now - timedelta(days=7)).strftime("%Y-%m-%d")
@@ -573,18 +583,19 @@ async def get_summary() -> Dict:
                       COALESCE(SUM(usd_spent), 0) as usd,
                       SUM(CASE WHEN status='done'   THEN 1 ELSE 0 END) as succeeded,
                       SUM(CASE WHEN status='failed' THEN 1 ELSE 0 END) as failed
-               FROM tasks WHERE created_at >= ?""",
-            (today,),
+               FROM tasks WHERE workspace=? AND created_at >= ?""",
+            (workspace, today),
         )).fetchone()
         w_row = await (await db.execute(
             """SELECT COUNT(*) as n,
                       COALESCE(SUM(usd_spent), 0) as usd,
                       SUM(CASE WHEN status='done'   THEN 1 ELSE 0 END) as succeeded,
                       SUM(CASE WHEN status='failed' THEN 1 ELSE 0 END) as failed
-               FROM tasks WHERE created_at >= ?""",
-            (week_ago,),
+               FROM tasks WHERE workspace=? AND created_at >= ?""",
+            (workspace, week_ago),
         )).fetchone()
     return {
+        "workspace": workspace,
         "tasks_today":        int(t_row["n"])        if t_row else 0,
         "tasks_this_week":    int(w_row["n"])        if w_row else 0,
         "succeeded_today":    int(t_row["succeeded"] or 0) if t_row else 0,

--- a/backend/main.py
+++ b/backend/main.py
@@ -284,12 +284,22 @@ def _prune_running_tasks() -> Dict[str, asyncio.Task]:
     return active
 
 
-async def _create_and_start_task(req) -> Dict:
+async def _active_task_count_for_workspace(workspace: str) -> int:
     active = _prune_running_tasks()
-    if len(active) >= settings.max_concurrent_tasks:
+    count = 0
+    for task_id in active:
+        task = await db.get_task(task_id)
+        if task and task.get("workspace") == workspace:
+            count += 1
+    return count
+
+
+async def _create_and_start_task(req) -> Dict:
+    active_count = await _active_task_count_for_workspace(req.workspace)
+    if active_count >= settings.max_concurrent_tasks:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"Too many active tasks ({len(active)}/{settings.max_concurrent_tasks}). Retry when one finishes.",
+            detail=f"Too many active tasks in workspace {req.workspace!r} ({active_count}/{settings.max_concurrent_tasks}). Retry when one finishes.",
         )
     task = await db.create_task(req.title, req.prompt, req.repo_url, workspace=req.workspace)
     task_id = task["id"]
@@ -416,6 +426,13 @@ class ArtifactVersionRequest(BaseModel):
     change_note: Optional[str] = None
 
 
+def _workspace_query(workspace: str = Query(default="personal")) -> str:
+    try:
+        return db.normalize_workspace(workspace)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -461,7 +478,7 @@ async def supervisor_plan(req: SupervisorPlanRequest):
 async def create_task(req: CreateTaskRequest, request: Request):
     # Daily budget cap (A8)
     if settings.daily_max_usd > 0:
-        daily_spend = await db.get_daily_spend()
+        daily_spend = await db.get_daily_spend(workspace=req.workspace)
         if daily_spend >= settings.daily_max_usd:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -479,9 +496,9 @@ async def create_task(req: CreateTaskRequest, request: Request):
 
 
 @app.get("/summary", dependencies=[Depends(require_auth)])
-async def summary():
+async def summary(workspace: str = Depends(_workspace_query)):
     """Return task counts and USD spend for today and the last 7 days (A9)."""
-    return await db.get_summary()
+    return await db.get_summary(workspace=workspace)
 
 
 @app.post("/artifacts", status_code=201, dependencies=[Depends(require_auth)])
@@ -601,15 +618,16 @@ async def operator_backup():
 async def list_tasks(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
+    workspace: str = Depends(_workspace_query),
 ):
     """Paginated task list (F29)."""
-    tasks = await db.list_tasks(limit=limit, offset=offset)
-    return {"tasks": tasks, "limit": limit, "offset": offset, "count": len(tasks), "max_task_usd": settings.max_task_usd}
+    tasks = await db.list_tasks(limit=limit, offset=offset, workspace=workspace)
+    return {"tasks": tasks, "workspace": workspace, "limit": limit, "offset": offset, "count": len(tasks), "max_task_usd": settings.max_task_usd}
 
 
 @app.get("/tasks/{task_id}", dependencies=[Depends(require_auth)])
-async def get_task(task_id: str):
-    task = await db.get_task(task_id)
+async def get_task(task_id: str, workspace: str = Depends(_workspace_query)):
+    task = await db.get_task(task_id, workspace=workspace)
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
     steps = await db.get_steps(task_id)
@@ -618,19 +636,22 @@ async def get_task(task_id: str):
 
 
 @app.delete("/tasks/{task_id}", dependencies=[Depends(require_auth)])
-async def cancel_task(task_id: str):
-    t = _running.get(task_id)
-    if t and not t.done():
-        t.cancel()
+async def cancel_task(task_id: str, workspace: str = Depends(_workspace_query)):
+    task = await db.get_task(task_id, workspace=workspace)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    running_task = _running.get(task_id)
+    if running_task and not running_task.done():
+        running_task.cancel()
     await db.update_task(task_id, status="cancelled")
     log.info("task_cancelled", task_id=task_id)
     return {"status": "cancelled"}
 
 
 @app.post("/tasks/{task_id}/retry", status_code=201, dependencies=[Depends(require_auth)])
-async def retry_task(task_id: str, request: Request):
+async def retry_task(task_id: str, request: Request, workspace: str = Depends(_workspace_query)):
     """Retry a failed/cancelled task. Retries share the task creation rate limit."""
-    original = await db.get_task(task_id)
+    original = await db.get_task(task_id, workspace=workspace)
     if not original:
         raise HTTPException(status_code=404, detail="Task not found")
     if original["status"] not in {"failed", "cancelled"}:
@@ -639,6 +660,7 @@ async def retry_task(task_id: str, request: Request):
         title=f"Retry: {original['title']}",
         prompt=original["prompt"],
         repo_url=original.get("repo_url"),
+        workspace=original["workspace"],
     )
     await _check_task_create_rate_limit(request)
     async with _task_creation_lock:
@@ -648,9 +670,9 @@ async def retry_task(task_id: str, request: Request):
 
 
 @app.get("/tasks/{task_id}/stream", dependencies=[Depends(require_auth)])
-async def stream_task(task_id: str, request: Request):
+async def stream_task(task_id: str, request: Request, workspace: str = Depends(_workspace_query)):
     """SSE stream with client-disconnect detection (F30)."""
-    task = await db.get_task(task_id)
+    task = await db.get_task(task_id, workspace=workspace)
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -328,8 +328,8 @@ async def test_two_sse_streams_for_same_task_receive_event():
             return False
 
     task = await db.create_task("SSE fanout", "prompt")
-    first = await stream_task(task["id"], ConnectedRequest())
-    second = await stream_task(task["id"], ConnectedRequest())
+    first = await stream_task(task["id"], ConnectedRequest(), workspace="personal")
+    second = await stream_task(task["id"], ConnectedRequest(), workspace="personal")
 
     await emit(task["id"], "task_done", {"ok": True})
 

--- a/tests/test_workspace_boundaries.py
+++ b/tests/test_workspace_boundaries.py
@@ -1,0 +1,163 @@
+"""Workspace boundary tests for personal/work task isolation."""
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend import db
+
+
+@pytest.fixture
+async def client():
+    from backend.main import _reset_task_create_rate_limiter, _running, app
+
+    _reset_task_create_rate_limiter()
+    _running.clear()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as async_client:
+        yield async_client
+    for task in _running.values():
+        task.cancel()
+    _running.clear()
+    _reset_task_create_rate_limiter()
+
+
+@pytest.mark.asyncio
+async def test_create_task_defaults_to_personal_workspace():
+    task = await db.create_task("Personal", "prompt")
+
+    assert task["workspace"] == "personal"
+    stored = await db.get_task(task["id"])
+    assert stored["workspace"] == "personal"
+
+
+@pytest.mark.asyncio
+async def test_db_get_task_can_filter_by_workspace():
+    work = await db.create_task("Work", "prompt", workspace="work")
+
+    assert await db.get_task(work["id"], workspace="personal") is None
+    assert (await db.get_task(work["id"], workspace="work"))["id"] == work["id"]
+
+
+@pytest.mark.asyncio
+async def test_db_list_tasks_filters_by_workspace():
+    personal = await db.create_task("Personal", "prompt", workspace="personal")
+    work = await db.create_task("Work", "prompt", workspace="work")
+
+    personal_rows = await db.list_tasks(workspace="personal")
+    work_rows = await db.list_tasks(workspace="work")
+
+    assert {row["id"] for row in personal_rows} == {personal["id"]}
+    assert {row["id"] for row in work_rows} == {work["id"]}
+
+
+@pytest.mark.asyncio
+async def test_db_summary_filters_by_workspace():
+    personal = await db.create_task("Personal", "prompt", workspace="personal")
+    work = await db.create_task("Work", "prompt", workspace="work")
+    await db.add_usd_spent(personal["id"], 0.25)
+    await db.add_usd_spent(work["id"], 1.00)
+
+    personal_summary = await db.get_summary(workspace="personal")
+    work_summary = await db.get_summary(workspace="work")
+
+    assert personal_summary["tasks_today"] == 1
+    assert personal_summary["total_usd_today"] == pytest.approx(0.25)
+    assert work_summary["tasks_today"] == 1
+    assert work_summary["total_usd_today"] == pytest.approx(1.00)
+
+
+@pytest.mark.asyncio
+async def test_db_daily_spend_filters_by_workspace():
+    personal = await db.create_task("Personal", "prompt", workspace="personal")
+    work = await db.create_task("Work", "prompt", workspace="work")
+    await db.add_usd_spent(personal["id"], 0.25)
+    await db.add_usd_spent(work["id"], 1.00)
+
+    assert await db.get_daily_spend(workspace="personal") == pytest.approx(0.25)
+    assert await db.get_daily_spend(workspace="work") == pytest.approx(1.00)
+
+
+@pytest.mark.asyncio
+async def test_api_create_and_list_filter_by_workspace(client):
+    with patch("backend.main.run_task", new=AsyncMock()):
+        personal = await client.post("/tasks", json={"title": "Personal", "prompt": "p"})
+        work = await client.post("/tasks", json={"title": "Work", "prompt": "p", "workspace": "work"})
+
+    assert personal.status_code == 201
+    assert work.status_code == 201
+    assert personal.json()["workspace"] == "personal"
+    assert work.json()["workspace"] == "work"
+
+    default_list = await client.get("/tasks")
+    work_list = await client.get("/tasks?workspace=work")
+
+    assert {task["id"] for task in default_list.json()["tasks"]} == {personal.json()["id"]}
+    assert {task["id"] for task in work_list.json()["tasks"]} == {work.json()["id"]}
+
+
+@pytest.mark.asyncio
+async def test_api_daily_budget_is_scoped_by_workspace(client, monkeypatch):
+    work = await db.create_task("Work", "prompt", workspace="work")
+    await db.add_usd_spent(work["id"], 1.00)
+    monkeypatch.setattr("backend.main.settings.daily_max_usd", 1.00)
+    monkeypatch.setattr("backend.main.settings.max_concurrent_tasks", 10)
+
+    with patch("backend.main.run_task", new=AsyncMock()):
+        personal_response = await client.post("/tasks", json={"title": "Personal", "prompt": "p"})
+        work_response = await client.post("/tasks", json={"title": "Work 2", "prompt": "p", "workspace": "work"})
+
+    assert personal_response.status_code == 201
+    assert work_response.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_api_concurrency_limit_is_scoped_by_workspace(client, monkeypatch):
+    started = asyncio.Event()
+
+    async def long_running(_task_id):
+        started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("backend.main.settings.max_concurrent_tasks", 1)
+    monkeypatch.setattr("backend.main.settings.daily_max_usd", 0)
+    with patch("backend.main.run_task", side_effect=long_running):
+        work_response = await client.post("/tasks", json={"title": "Work", "prompt": "p", "workspace": "work"})
+        await started.wait()
+        personal_response = await client.post("/tasks", json={"title": "Personal", "prompt": "p"})
+
+    assert work_response.status_code == 201
+    assert personal_response.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_api_get_task_requires_matching_workspace(client):
+    work = await db.create_task("Work", "prompt", workspace="work")
+
+    default_response = await client.get(f"/tasks/{work['id']}")
+    work_response = await client.get(f"/tasks/{work['id']}?workspace=work")
+
+    assert default_response.status_code == 404
+    assert work_response.status_code == 200
+    assert work_response.json()["task"]["workspace"] == "work"
+
+
+@pytest.mark.asyncio
+async def test_api_retry_preserves_workspace_and_blocks_cross_workspace_retry(client):
+    work = await db.create_task("Work", "prompt", workspace="work")
+    await db.update_task(work["id"], status="failed", error="boom")
+
+    wrong_workspace = await client.post(f"/tasks/{work['id']}/retry")
+    with patch("backend.main.run_task", new=AsyncMock()):
+        right_workspace = await client.post(f"/tasks/{work['id']}/retry?workspace=work")
+
+    assert wrong_workspace.status_code == 404
+    assert right_workspace.status_code == 201
+    assert right_workspace.json()["workspace"] == "work"
+
+
+@pytest.mark.asyncio
+async def test_invalid_workspace_is_rejected(client):
+    response = await client.post("/tasks", json={"title": "Bad", "prompt": "p", "workspace": "shared"})
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Scope
- Add task workspace persistence with personal/work validation and migration defaulting existing tasks to personal.
- Scope task list, task detail, summary, retry, cancel, stream, daily budget, and concurrency checks by workspace.
- Preserve simple default flow by treating omitted workspace as personal.
- Add DB and API boundary tests for cross-workspace leakage, resource limits, invalid workspace rejection, and retry preservation.

## Validation
- Python compile: passed.
- Focused tests: pytest tests/test_workspace_boundaries.py tests/test_api.py tests/test_db.py -q passed, 42 tests.
- Full tests: pytest tests/ -q passed, 155 tests.
- Dependency audit: pip-audit -r requirements.txt --format=json --strict passed with no known vulnerabilities.
- Independent Explore review: initial Medium findings fixed; final review reported no High/Medium blockers.

## Notes
- GitHub Advanced Security secret scanning is not enabled on this repository, so MCP secret scanning could not run.
- Artifact/memory tables are not present on current main; this PR establishes task-level workspace boundaries for later artifact/memory APIs to reuse.

## Rollback
- Revert commit 7942a6e to remove workspace-scoped task APIs and schema migration.