### PR TITLE
feat: add artifact studio and recipe library polish

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ from backend.events import subscribe, unsubscribe
 from backend.notifier import notify_task_failure
 from backend.recipes import list_recipes, normalize_workspace
 from backend.supervisor import plan_task
+from backend.operator_studio import artifact_index, handoff_summary, recipe_catalog, run_history
 
 
 # ---------------------------------------------------------------------------
@@ -623,6 +624,47 @@ async def list_tasks(
     """Paginated task list (F29)."""
     tasks = await db.list_tasks(limit=limit, offset=offset, workspace=workspace)
     return {"tasks": tasks, "workspace": workspace, "limit": limit, "offset": offset, "count": len(tasks), "max_task_usd": settings.max_task_usd}
+
+
+@app.get("/operator/recipes", dependencies=[Depends(require_auth)])
+async def operator_recipes(category: str = Query(default="")):
+    """Built-in recipe previews for the operator studio."""
+    return recipe_catalog(category=category)
+
+
+@app.get("/operator/run-history", dependencies=[Depends(require_auth)])
+async def operator_run_history(
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+):
+    """Recent task runs summarized for fast operator review."""
+    tasks = await db.list_tasks(limit=limit, offset=offset)
+    data = run_history(tasks)
+    data.update({"limit": limit, "offset": offset})
+    return data
+
+
+@app.get("/operator/artifacts", dependencies=[Depends(require_auth)])
+async def operator_artifacts(
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+):
+    """Derived artifact index backed by task runs until artifact tables land."""
+    tasks = await db.list_tasks(limit=limit, offset=offset)
+    data = artifact_index(tasks)
+    data.update({"limit": limit, "offset": offset})
+    return data
+
+
+@app.get("/operator/handoff/{task_id}", dependencies=[Depends(require_auth)])
+async def operator_handoff(task_id: str):
+    """Traceable handoff summary for a single task."""
+    task = await db.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    steps = await db.get_steps(task_id)
+    logs = await db.get_logs(task_id)
+    return handoff_summary(task, steps, logs)
 
 
 @app.get("/tasks/{task_id}", dependencies=[Depends(require_auth)])

--- a/backend/operator_studio.py
+++ b/backend/operator_studio.py
@@ -1,0 +1,126 @@
+"""Operator studio helpers for recipes, run history, and handoff summaries."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+_RECIPES: List[Dict[str, Any]] = [
+    {
+        "id": "market-research",
+        "name": "Market Research",
+        "category": "general",
+        "description": "Compare competitors, extract positioning, and produce a source-backed brief.",
+        "stages": ["scope", "gather sources", "compare", "recommend"],
+        "artifacts": ["research_brief", "comparison_matrix"],
+        "approval_gates": ["external source review"],
+        "editable": False,
+    },
+    {
+        "id": "build-mvp",
+        "name": "Build MVP",
+        "category": "personal",
+        "description": "Turn a product idea into a small tested implementation plan and first build.",
+        "stages": ["requirements", "design", "build", "validate", "handoff"],
+        "artifacts": ["code_diff", "handoff_summary"],
+        "approval_gates": ["dependency install", "deployment"],
+        "editable": False,
+    },
+    {
+        "id": "lead-qualification",
+        "name": "Lead Qualification Workflow",
+        "category": "work",
+        "description": "Prepare a repeatable workflow for qualifying and enriching leads.",
+        "stages": ["input audit", "enrichment plan", "workflow build", "review"],
+        "artifacts": ["workflow", "spreadsheet", "automation_blueprint"],
+        "approval_gates": ["customer data access", "external system write"],
+        "editable": False,
+    },
+    {
+        "id": "fix-failure",
+        "name": "Fix Failure",
+        "category": "general",
+        "description": "Diagnose a failing run, patch the root cause, and summarize the fix.",
+        "stages": ["triage", "patch", "test", "handoff"],
+        "artifacts": ["code_diff", "run_history", "handoff_summary"],
+        "approval_gates": ["protected path edit"],
+        "editable": False,
+    },
+]
+
+
+def recipe_catalog(category: str = "") -> Dict[str, Any]:
+    selected = [recipe for recipe in _RECIPES if not category or recipe["category"] == category]
+    return {
+        "recipes": selected,
+        "count": len(selected),
+        "categories": sorted({recipe["category"] for recipe in _RECIPES}),
+        "policy": "Built-in recipes are preview-only in this slice; edits require a future policy-gated write path.",
+    }
+
+
+def run_history(tasks: List[Dict[str, Any]]) -> Dict[str, Any]:
+    rows = []
+    for task in tasks:
+        rows.append({
+            "task_id": task["id"],
+            "title": task["title"],
+            "status": task["status"],
+            "branch": task.get("branch"),
+            "pr_url": task.get("pr_url"),
+            "current_step": task.get("current_step") or 0,
+            "last_action": task.get("last_action"),
+            "last_tool": task.get("last_tool"),
+            "usd_spent": float(task.get("usd_spent") or 0),
+            "updated_at": task.get("updated_at"),
+        })
+    return {"runs": rows, "count": len(rows)}
+
+
+def artifact_index(tasks: List[Dict[str, Any]]) -> Dict[str, Any]:
+    artifacts = []
+    for task in tasks:
+        artifact_type = "handoff_summary" if task.get("status") in {"done", "failed", "cancelled"} else "run_snapshot"
+        artifacts.append({
+            "id": f"task:{task['id']}",
+            "artifact_type": artifact_type,
+            "title": task["title"],
+            "task_id": task["id"],
+            "status": task["status"],
+            "trace": {
+                "branch": task.get("branch"),
+                "pr_url": task.get("pr_url"),
+                "last_tool": task.get("last_tool"),
+                "recovery_note": task.get("recovery_note"),
+            },
+        })
+    return {"artifacts": artifacts, "count": len(artifacts), "source": "tasks"}
+
+
+def handoff_summary(task: Dict[str, Any], steps: List[Dict[str, Any]], logs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    completed_steps = [step for step in steps if step.get("status") == "done"]
+    failed_steps = [step for step in steps if step.get("status") == "failed"]
+    summary_lines = [
+        f"Task: {task['title']}",
+        f"Status: {task['status']}",
+        f"Branch: {task.get('branch') or 'none'}",
+        f"Pull request: {task.get('pr_url') or 'none'}",
+        f"Steps: {len(steps)} total, {len(completed_steps)} completed, {len(failed_steps)} failed",
+    ]
+    if task.get("error"):
+        summary_lines.append(f"Error: {task['error']}")
+    if task.get("recovery_note"):
+        summary_lines.append(f"Recovery: {task['recovery_note']}")
+    return {
+        "artifact_type": "handoff_summary",
+        "task_id": task["id"],
+        "title": task["title"],
+        "status": task["status"],
+        "summary": "\n".join(summary_lines),
+        "trace": {
+            "branch": task.get("branch"),
+            "pr_url": task.get("pr_url"),
+            "last_action": task.get("last_action"),
+            "last_tool": task.get("last_tool"),
+            "log_count": len(logs),
+        },
+    }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -407,6 +407,22 @@
     </main>
   </div>
 
+  <!-- Operator Studio panels — artifact/recipe/run previews -->
+  <div id="operator-studio" style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;padding:0 20px 20px">
+    <section class="panel" style="padding:14px">
+      <div class="panel-header" style="padding:0 0 8px"><h2 style="font-size:0.9rem">Artifact Studio</h2><span id="artifact-count" class="subtle">0</span></div>
+      <div id="artifact-preview" class="subtle" style="font-size:0.78rem"><p>No artifacts loaded yet.</p></div>
+    </section>
+    <section class="panel" style="padding:14px">
+      <div class="panel-header" style="padding:0 0 8px"><h2 style="font-size:0.9rem">Recipe Library</h2><span id="recipe-count" class="subtle">0</span></div>
+      <div id="recipe-preview" class="subtle" style="font-size:0.78rem"><p>No recipes loaded yet.</p></div>
+    </section>
+    <section class="panel" style="padding:14px">
+      <div class="panel-header" style="padding:0 0 8px"><h2 style="font-size:0.9rem">Run History</h2><span id="run-count" class="subtle">0</span></div>
+      <div id="run-preview" class="subtle" style="font-size:0.78rem"><p>No runs loaded yet.</p></div>
+    </section>
+  </div>
+
   <script>
     function escHtml(value) {
       if (value == null) return '';
@@ -694,9 +710,53 @@
       }
     }
 
+    function renderPreviewRows(items, emptyText, renderRow) {
+      if (!items || !items.length) return '<p>' + escHtml(emptyText) + '</p>';
+      return items.slice(0, 3).map(renderRow).join('');
+    }
+
+    async function loadOperatorStudio() {
+      try {
+        const headers = readHeaders(false);
+        const [artifactResponse, recipeResponse, runResponse] = await Promise.all([
+          fetch(API + '/operator/artifacts?limit=5', { headers }),
+          fetch(API + '/operator/recipes', { headers }),
+          fetch(API + '/operator/run-history?limit=5', { headers })
+        ]);
+        if (artifactResponse.ok) {
+          const data = await artifactResponse.json();
+          document.getElementById('artifact-count').textContent = String(data.count || 0);
+          document.getElementById('artifact-preview').innerHTML = renderPreviewRows(
+            data.artifacts || [],
+            'No task-backed artifacts yet.',
+            item => '<p><span>' + escHtml(item.artifact_type) + '</span> ' + escHtml(item.title) + '</p>'
+          );
+        }
+        if (recipeResponse.ok) {
+          const data = await recipeResponse.json();
+          document.getElementById('recipe-count').textContent = String(data.count || 0);
+          document.getElementById('recipe-preview').innerHTML = renderPreviewRows(
+            data.recipes || [],
+            'No recipes available.',
+            item => '<p><span>' + escHtml(item.name) + '</span> ' + escHtml(item.category) + '</p>'
+          );
+        }
+        if (runResponse.ok) {
+          const data = await runResponse.json();
+          document.getElementById('run-count').textContent = String(data.count || 0);
+          document.getElementById('run-preview').innerHTML = renderPreviewRows(
+            data.runs || [],
+            'No recent runs yet.',
+            item => '<p><span class="' + escHtml('status-' + item.status) + '">' + escHtml(item.status) + '</span> ' + escHtml(item.title) + '</p>'
+          );
+        }
+      } catch { /* non-fatal */ }
+    }
+
     function loadAll() {
       loadTasks();
       loadSummary();
+      loadOperatorStudio();
     }
 
     loadAll();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   testMatch: /.*\.spec\.ts/,
+  timeout: 30_000,
   use: {
     baseURL: 'http://127.0.0.1:3100',
   },
@@ -10,7 +11,7 @@ export default defineConfig({
     command: 'npx tsx scripts/smoke-server.ts',
     url: 'http://127.0.0.1:3100',
     env: { PORT: '3100' },
-    reuseExistingServer: !process.env.CI,
-    timeout: 15000,
+    reuseExistingServer: true,
+    timeout: 30_000,
   },
 });

--- a/scripts/smoke-server.ts
+++ b/scripts/smoke-server.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { URL } from 'url';
 
-const PORT = Number(process.env.PORT ?? 3000);
+const PORT = Number(process.env.PORT || 3100);
 
 function escapeHtml(s: string): string {
   return s

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -8,6 +8,13 @@ test('homepage loads with app title', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'Run Agent' })).toBeVisible();
 });
 
+test('homepage shows operator studio panels', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Artifact Studio' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Recipe Library' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Run History' })).toBeVisible();
+});
+
 test('/success?test=1 returns task complete message', async ({ page }) => {
   await page.goto('/success?test=1');
   await expect(page.locator('body')).toContainText('Task complete');

--- a/tests/test_operator_studio.py
+++ b/tests/test_operator_studio.py
@@ -1,0 +1,95 @@
+"""Tests for operator studio recipes, artifacts, run history, and handoff APIs."""
+from httpx import ASGITransport, AsyncClient
+import pytest
+
+from backend import db
+
+
+@pytest.fixture
+async def client():
+    from backend.main import _reset_task_create_rate_limiter, _running, app
+
+    _reset_task_create_rate_limiter()
+    _running.clear()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as async_client:
+        yield async_client
+    for task in _running.values():
+        task.cancel()
+    _running.clear()
+    _reset_task_create_rate_limiter()
+
+
+@pytest.mark.asyncio
+async def test_recipe_catalog_lists_preview_only_recipes(client):
+    response = await client.get("/operator/recipes")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] >= 1
+    assert "general" in data["categories"]
+    assert all(recipe["editable"] is False for recipe in data["recipes"])
+
+
+@pytest.mark.asyncio
+async def test_recipe_catalog_filters_by_category(client):
+    response = await client.get("/operator/recipes?category=work")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] >= 1
+    assert {recipe["category"] for recipe in data["recipes"]} == {"work"}
+
+
+@pytest.mark.asyncio
+async def test_operator_artifacts_are_derived_from_tasks(client):
+    task = await db.create_task("Completed", "prompt")
+    await db.update_task(task["id"], status="done", pr_url="https://github.com/example/repo/pull/1", last_tool="github_create_pr")
+
+    response = await client.get("/operator/artifacts")
+
+    assert response.status_code == 200
+    artifacts = response.json()["artifacts"]
+    assert artifacts[0]["id"] == f"task:{task['id']}"
+    assert artifacts[0]["artifact_type"] == "handoff_summary"
+    assert artifacts[0]["trace"]["pr_url"] == "https://github.com/example/repo/pull/1"
+
+
+@pytest.mark.asyncio
+async def test_operator_run_history_summarizes_recent_tasks(client):
+    task = await db.create_task("Run", "prompt")
+    await db.update_task(task["id"], status="running", current_step=2, last_action="tool_call")
+
+    response = await client.get("/operator/run-history")
+
+    assert response.status_code == 200
+    runs = response.json()["runs"]
+    assert runs[0]["task_id"] == task["id"]
+    assert runs[0]["current_step"] == 2
+    assert runs[0]["last_action"] == "tool_call"
+
+
+@pytest.mark.asyncio
+async def test_operator_handoff_is_traceable(client):
+    task = await db.create_task("Handoff", "prompt")
+    await db.update_task(task["id"], status="failed", error="boom", branch="task/handoff", last_tool="run_tests")
+    step_id = await db.create_step(task["id"], 1, tool_name="run_tests")
+    await db.update_step(step_id, status="failed", tool_output="tests failed")
+    await db.add_log(task["id"], "error", "tests failed")
+
+    response = await client.get(f"/operator/handoff/{task['id']}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["artifact_type"] == "handoff_summary"
+    assert data["task_id"] == task["id"]
+    assert "Status: failed" in data["summary"]
+    assert data["trace"]["branch"] == "task/handoff"
+    assert data["trace"]["last_tool"] == "run_tests"
+    assert data["trace"]["log_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_operator_handoff_missing_task_returns_404(client):
+    response = await client.get("/operator/handoff/missing")
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Scope
- Add read-only operator studio backend helpers for recipe previews, task-backed artifact index, run history, and traceable handoff summaries.
- Add authenticated operator endpoints under /operator/* without introducing write/edit paths.
- Add frontend Artifact Studio, Recipe Library, and Run History panels that fail safely if the API is unavailable.
- Add Playwright config and configurable smoke server port for stable frontend smoke coverage.

## Validation
- Python compile: passed.
- Focused API tests: pytest tests/test_operator_studio.py tests/test_api.py -q passed, 23 tests.
- TypeScript check: npx tsc --noEmit passed.
- Playwright smoke: npx playwright test tests/smoke.spec.ts passed, 4 tests.
- Full tests: pytest tests/ -q passed, 150 tests.
- Dependency audit: pip-audit -r requirements.txt --format=json --strict passed with no known vulnerabilities.
- Independent Explore review: no High/Medium blockers.

## Notes
- GitHub Advanced Security secret scanning is not enabled on this repository, so MCP secret scanning could not run.
- Artifact Studio is task-backed in this independent branch because the artifact table PR is still unmerged.

## Rollback
- Revert commit 72292f7 to remove operator studio endpoints, UI panels, and smoke config.