### PR TITLE
fix: remove unused json import (unblocks CI for all roadmap PRs)

### DIFF
--- a/backend/tool_adapters.py
+++ b/backend/tool_adapters.py
@@ -9,7 +9,6 @@ v2: Fixed @retry decorators (F4/E3).
     Unbounded _repo_cache replaced with bounded LRU (F11).
 """
 import glob
-import json
 import os
 import re
 import shutil


### PR DESCRIPTION
## Summary
Removes the unused `import json` from `backend/tool_adapters.py` line 12.

## Root Cause
PR6 (research tools) added `import json` but the final implementation used `orjson` instead, leaving this import orphaned. Ruff F401 fails on every PR that inherits this change.

## Effect
Merging this PR restores a clean lint baseline. All 7 roadmap PRs (#56–#62) will pass CI once they are rebased onto or merge after this fix.